### PR TITLE
Feat/email auth

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/auth/controller/EmailVerifyController.java
+++ b/src/main/java/com/halo/core_bridge/api/auth/controller/EmailVerifyController.java
@@ -1,0 +1,46 @@
+package com.halo.core_bridge.api.auth.controller;
+
+import com.halo.core_bridge.api.auth.model.AuthCodeMail;
+import com.halo.core_bridge.api.auth.service.AuthService;
+import com.halo.core_bridge.api.mail.service.AuthCodeMailService;
+import com.halo.core_bridge.api.users.service.UserService;
+import com.halo.core_bridge.common.model.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class EmailVerifyController {
+
+    private final AuthCodeMailService authCodeMailService;
+    private final AuthService authService;
+    private final UserService userService;
+
+    /**
+     * 이메일로 인증번호 보내기
+     * @param email 전송할 이메일
+     */
+    @GetMapping("/email/verify-code")
+    public ResponseEntity<BaseResponse<Object>> sendAuthCode(String email) {
+
+        // 이메일 중복 검사
+        userService.existByEmail(email);
+
+        // 이메일 전송
+        authCodeMailService.sendToEmail(email);
+        return ResponseEntity.ok(BaseResponse.success("인증 번호 전송 성공"));
+    }
+
+    /**
+     * 인증번호 검증
+     * @param authCodeMail 검증하기 위한 이메일과 인증 번호를 담은 <code>DTO</code>
+     */
+    @PostMapping("/email/verify-code")
+    public ResponseEntity<BaseResponse<Object>> verifyCode(@RequestBody AuthCodeMail authCodeMail) {
+
+        authService.verifyAuthCode(authCodeMail);
+        return ResponseEntity.ok(BaseResponse.success("이메일 인증 성공"));
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/auth/model/AuthCodeMail.java
+++ b/src/main/java/com/halo/core_bridge/api/auth/model/AuthCodeMail.java
@@ -1,0 +1,11 @@
+package com.halo.core_bridge.api.auth.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AuthCodeMail {
+    private String code;
+    private String email;
+}

--- a/src/main/java/com/halo/core_bridge/api/auth/service/AuthCodeCreator.java
+++ b/src/main/java/com/halo/core_bridge/api/auth/service/AuthCodeCreator.java
@@ -1,0 +1,22 @@
+package com.halo.core_bridge.api.auth.service;
+
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+
+@Service
+public class AuthCodeCreator {
+
+    private static final int NUMBER_BOUND = 1000000;
+
+    /**
+     * 인증 번호를 생성한다.
+     * @return <code>AuthCode</code> - 문자열 타입의 인증번호를 담은 객체
+     */
+    public String generateAuthCode() {
+        SecureRandom secureRandom = new SecureRandom();
+        int randomCode = secureRandom.nextInt(NUMBER_BOUND);
+
+        return String.format("%06d", randomCode);
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/auth/service/AuthService.java
+++ b/src/main/java/com/halo/core_bridge/api/auth/service/AuthService.java
@@ -1,0 +1,41 @@
+package com.halo.core_bridge.api.auth.service;
+
+import com.halo.core_bridge.api.auth.model.AuthCodeMail;
+import com.halo.core_bridge.api.mail.model.MailSend;
+import com.halo.core_bridge.common.exception.BaseException;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * 인증 번호를 검증한다.
+     * @param authCodeMail 이메일과 인증 코드가 담긴 dto
+     * @throws BaseException 유효하지 않은 인증번호일 때 예외 발생
+     */
+    public void verifyAuthCode(AuthCodeMail authCodeMail) {
+
+        String redisKey = MailSend.AUTH_CODE_MAIL.createRedisKey(authCodeMail.getEmail());
+        String findAuthCode = getValue(redisKey);
+
+        if (findAuthCode == null || !findAuthCode.equals(authCodeMail.getCode())) {
+            throw BaseException.from(BaseResponseStatus.INVALID_AUTH_CODE);
+        }
+
+        deleteByRedisKey(redisKey);
+    }
+
+    private String getValue(String redisKey) {
+        return stringRedisTemplate.opsForValue().get(redisKey);
+    }
+
+    private void deleteByRedisKey(String redisKey) {
+        stringRedisTemplate.delete(redisKey);
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/mail/model/MailSend.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/model/MailSend.java
@@ -1,0 +1,17 @@
+package com.halo.core_bridge.api.mail.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MailSend {
+    AUTH_CODE_MAIL("[CoreBridge] 안녕하세요. 요청하신 인증번호를 보내드립니다.", "AUTH_CODE_MAIL:");
+
+    private final String subject;
+    private final String keyName;
+
+    public String createRedisKey(String param) {
+        return keyName.concat(param);
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/mail/service/AuthCodeMailService.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/service/AuthCodeMailService.java
@@ -1,0 +1,67 @@
+package com.halo.core_bridge.api.mail.service;
+
+import com.halo.core_bridge.api.auth.service.AuthCodeCreator;
+import com.halo.core_bridge.api.mail.model.MailSend;
+import jakarta.mail.internet.MimeMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+public class AuthCodeMailService extends BaseMailService {
+
+
+    private final AuthCodeCreator authCodeCreator;
+    private final StringRedisTemplate redisTemplate;
+
+    private String authCode;
+
+    public AuthCodeMailService(JavaMailSender mailSender, AuthCodeCreator authCodeCreator, StringRedisTemplate redisTemplate) {
+        super(mailSender, MailSend.AUTH_CODE_MAIL.getSubject());
+        this.authCodeCreator = authCodeCreator;
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void sendToEmail(String email) {
+        authCode = authCodeCreator.generateAuthCode();
+
+        MimeMessage mimeMessage = createMimeMessage(email);
+        redisTemplate.opsForValue().set(createRedisKey(email), authCode, Duration.ofMinutes(5));
+
+        mailSender.send(mimeMessage);
+    }
+
+    @Override
+    protected String createView() {
+        String rawView = """
+                 <html>
+                     <head>
+                     </head>
+                 <body>
+                     <p>
+                         안녕하세요.<br>
+                         저희 <b>CoreBridge</b>을 이용해 주셔서 감사합니다.<br>
+                         요청하신 인증 번호를 보내드립니다.
+                     </p>
+                 <strong style="font-size:40px">
+                     %s
+                 </strong>
+                     <p>
+                         위의 인증번호 6자리를 인증번호 입력창에 입력해주세요.<br>
+                         <font size=1><b>개인정보 보호를 위해서 인증번호는 5분간 유지됩니다.</b></font>
+                     </p>
+                 </body>
+                 </html>
+                """;
+        return String.format(rawView, authCode);
+    }
+
+    private String createRedisKey(String email) {
+        return MailSend.AUTH_CODE_MAIL.createRedisKey(email);
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/mail/service/BaseMailService.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/service/BaseMailService.java
@@ -1,0 +1,61 @@
+package com.halo.core_bridge.api.mail.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+@Slf4j
+public abstract class BaseMailService {
+
+    protected final JavaMailSender mailSender;
+
+    protected static final boolean IS_HTML = true;
+    protected static final String DEFAULT_ENCODE = "UTF-8";
+
+    protected String subject = "[CoreBridge] 안녕하세요. CoreBridge에서 알립니다.";
+
+    protected BaseMailService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public BaseMailService(JavaMailSender mailSender, String subject) {
+        this.mailSender = mailSender;
+        this.subject = subject;
+    }
+
+    public void sendToEmail(String email) {
+        MimeMessage mimeMessage = createMimeMessage(email);
+        mailSender.send(mimeMessage);
+    }
+
+    /**
+     * MimeMessage 생성
+     *
+     * @param email 전송할 이메일
+     * @return MimeMessage
+     */
+    protected MimeMessage createMimeMessage(String email) {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+
+        try {
+
+            MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, true, DEFAULT_ENCODE);
+            messageHelper.setTo(email);
+            messageHelper.setSubject(subject);
+            messageHelper.setText(createView(), IS_HTML);
+
+        } catch (MessagingException e) {
+            log.error(e.getMessage(), e);
+        }
+
+        return mimeMessage;
+    }
+
+    /**
+     * 이메일에 보여주기 위한 내용 추가
+     * @return String 형식의 html
+     */
+    protected abstract String createView();
+}

--- a/src/main/java/com/halo/core_bridge/api/users/repository/UserRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/users/repository/UserRepository.java
@@ -4,4 +4,5 @@ import com.halo.core_bridge.api.users.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/halo/core_bridge/api/users/service/UserService.java
+++ b/src/main/java/com/halo/core_bridge/api/users/service/UserService.java
@@ -32,4 +32,15 @@ public class UserService {
             throw e;
         }
     }
+
+    /**
+     * 이메일 중복을 검사한다.
+     * @param email 중복인지 확인할 이메일
+     * @throws BaseException 이메일 중복 예외 발생
+     */
+    public void existByEmail(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw BaseException.from(BaseResponseStatus.DUPLICATE_USER_EMAIL);
+        }
+    }
 }

--- a/src/test/java/com/halo/core_bridge/api/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/halo/core_bridge/api/auth/service/AuthServiceTest.java
@@ -1,0 +1,75 @@
+package com.halo.core_bridge.api.auth.service;
+
+import com.halo.core_bridge.api.auth.model.AuthCodeMail;
+import com.halo.core_bridge.api.users.service.UserService;
+import com.halo.core_bridge.common.exception.BaseException;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    @DisplayName("이메일 인증 성공")
+    void verifyAuthCode() {
+        // given
+        AuthCodeMail authCodeMail = AuthCodeMail.builder()
+                .code("123456")
+                .email("test@test.com")
+                .build();
+
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(any(String.class))).willReturn("123456");
+
+        willDoNothing().given(userService).existByEmail(any(String.class));
+
+        // when
+        // then
+        assertDoesNotThrow(() -> authService.verifyAuthCode(authCodeMail));
+    }
+
+    @Test
+    @DisplayName("잘못된 인증번호 예외 발생")
+    void incorrectAuthCode() {
+        // given
+        AuthCodeMail authCodeMail = AuthCodeMail.builder()
+                .code("123457")
+                .email("test@test.com")
+                .build();
+
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(any(String.class))).willReturn("123456");
+
+        willDoNothing().given(userService).existByEmail(any(String.class));
+
+        // when
+        // then
+        BaseException exception = assertThrows(BaseException.class, () -> authService.verifyAuthCode(authCodeMail));
+        assertThat(exception.getStatus()).isEqualTo(BaseResponseStatus.INVALID_AUTH_CODE);
+    }
+}

--- a/src/test/java/com/halo/core_bridge/api/users/service/UserServiceTest.java
+++ b/src/test/java/com/halo/core_bridge/api/users/service/UserServiceTest.java
@@ -6,12 +6,11 @@ import com.halo.core_bridge.api.users.model.entity.User;
 import com.halo.core_bridge.api.users.model.entity.UserRole;
 import com.halo.core_bridge.api.users.repository.UserRepository;
 import com.halo.core_bridge.common.exception.BaseException;
-import org.assertj.core.api.Assertions;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -20,8 +19,11 @@ import org.springframework.dao.DataIntegrityViolationException;
 import java.sql.SQLException;
 import java.time.LocalDate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
@@ -52,7 +54,7 @@ class UserServiceTest {
                 )
                 .build();
 
-        BDDMockito.given(userRepository.save(any(User.class))).willReturn(willReturnUser);
+        given(userRepository.save(any(User.class))).willReturn(willReturnUser);
 
         UserDto.Create createUser = UserDto.Create.builder()
                 .email("test01@test.com")
@@ -67,7 +69,7 @@ class UserServiceTest {
         Long savedKey = userService.save(createUser);
 
         // then
-        Assertions.assertThat(willReturnUser.getId()).isEqualTo(savedKey);
+        assertThat(willReturnUser.getId()).isEqualTo(savedKey);
         then(userRepository).should(times(1)).save(any(User.class));
     }
 
@@ -85,7 +87,7 @@ class UserServiceTest {
         DataIntegrityViolationException springEx =
                 new DataIntegrityViolationException("무결성 위반", hibernateEx);
 
-        BDDMockito.given(userRepository.save(any(User.class))).willThrow(springEx);
+        given(userRepository.save(any(User.class))).willThrow(springEx);
 
         UserDto.Create createUser = UserDto.Create.builder()
                 .email("test01@test.com")
@@ -99,5 +101,28 @@ class UserServiceTest {
         // when
         // then
         assertThrows(BaseException.class, () -> userService.save(createUser));
+    }
+
+    @Test
+    @DisplayName("이메일 중복 예외 발생")
+    void existEmail() {
+        // given
+        given(userRepository.existsByEmail(any(String.class))).willReturn(true);
+
+        // when
+        // then
+        BaseException exception = assertThrows(BaseException.class, () -> userService.existByEmail("test@test.com"));
+        assertThat(exception.getStatus()).isEqualTo(BaseResponseStatus.DUPLICATE_USER_EMAIL);
+    }
+
+    @Test
+    @DisplayName("이메일 중복 검사 성공")
+    void noExistEmail() {
+        // given
+        given(userRepository.existsByEmail(any(String.class))).willReturn(false);
+
+        // when
+        // then
+        assertDoesNotThrow(() -> userService.existByEmail("test@test.com"));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

closes #37 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 기본 이메일 전송 서비스를 구현하고 인증번호를 전송하는 전용 서비스 클래스를 생성
2. 인증번호를 요청받으면 인증번호를 검증하는 기능 구현
3. 회원 가입 인증이 필요한 이메일이 이미 존재하는 이메일이라면 중복 예외를 발생
4. 유효하지 않은 인증번호를 검증 요청한 경우 예외를 발생시킨다.

### 스크린샷 (선택)

* 이메일 인증 번호 전송 성공
<img width="1360" height="772" alt="image" src="https://github.com/user-attachments/assets/5a415ebb-fc8a-4d81-a2e0-448c3b9c1fba" />

* 회원 가입 인증이 필요한 이메일이 이미 존재하는 이메일이라면 중복 예외 발생
<img width="1369" height="800" alt="image" src="https://github.com/user-attachments/assets/9bfcb9cc-20e3-4639-a8c1-99b88d443d27" />

* 올바른 인증번호를 입력
<img width="1363" height="768" alt="image" src="https://github.com/user-attachments/assets/b72ed019-ded9-4b12-bced-ec840ac6d4b3" />

* 유효하지 않은 인증 번호 입력
<img width="1364" height="785" alt="image" src="https://github.com/user-attachments/assets/73ac46ae-ae47-493e-a288-5beea0f030ba" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?