### PR TITLE
feat: 로그인 기능 구현 (#44)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,11 @@ dependencies {
 	// Spring Security 추가
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/halo/core_bridge/api/token/filter/AlreadyLoginFilter.java
+++ b/src/main/java/com/halo/core_bridge/api/token/filter/AlreadyLoginFilter.java
@@ -1,0 +1,58 @@
+package com.halo.core_bridge.api.token.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.core_bridge.api.token.jwt.JwtTokenService;
+import com.halo.core_bridge.api.token.refresh.service.RefreshTokenService;
+import com.halo.core_bridge.common.model.BaseResponse;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
+import com.halo.core_bridge.utils.CookieUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class AlreadyLoginFilter extends OncePerRequestFilter {
+
+    private final RefreshTokenService refreshTokenService;
+    private final JwtTokenService jwtTokenService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (request.getRequestURI().equals("/login") && authentication != null) {
+
+            String refreshToken = CookieUtil.getCookieValue(request, refreshTokenService.getTokenName());
+
+            if (refreshToken == null) {
+
+                // 쿠키 삭제
+                CookieUtil.deleteCookie(response, jwtTokenService.getTokenName());
+                CookieUtil.deleteCookie(response, refreshTokenService.getTokenName());
+
+                response.setContentType("application/json; charset=UTF-8");
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write(
+                        new ObjectMapper().writeValueAsString(
+                                BaseResponse.error(BaseResponseStatus.INVALID_REFRESH_TOKEN)
+                        )
+                );
+
+                return;
+            }
+
+            refreshTokenService.delete(refreshToken);
+
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/token/filter/AlreadyLoginFilter.java
+++ b/src/main/java/com/halo/core_bridge/api/token/filter/AlreadyLoginFilter.java
@@ -3,6 +3,7 @@ package com.halo.core_bridge.api.token.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.halo.core_bridge.api.token.jwt.JwtTokenService;
 import com.halo.core_bridge.api.token.refresh.service.RefreshTokenService;
+import com.halo.core_bridge.common.exception.BaseException;
 import com.halo.core_bridge.common.model.BaseResponse;
 import com.halo.core_bridge.common.model.BaseResponseStatus;
 import com.halo.core_bridge.utils.CookieUtil;
@@ -28,31 +29,31 @@ public class AlreadyLoginFilter extends OncePerRequestFilter {
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (request.getRequestURI().equals("/login") && authentication != null) {
+        try {
+            if (request.getRequestURI().equals("/login") && authentication != null) {
 
-            String refreshToken = CookieUtil.getCookieValue(request, refreshTokenService.getTokenName());
-
-            if (refreshToken == null) {
-
-                // 쿠키 삭제
-                CookieUtil.deleteCookie(response, jwtTokenService.getTokenName());
-                CookieUtil.deleteCookie(response, refreshTokenService.getTokenName());
-
-                response.setContentType("application/json; charset=UTF-8");
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.getWriter().write(
-                        new ObjectMapper().writeValueAsString(
-                                BaseResponse.error(BaseResponseStatus.INVALID_REFRESH_TOKEN)
-                        )
-                );
-
-                return;
+                String refreshToken = CookieUtil.getCookieValue(request, refreshTokenService.getTokenName());
+                refreshTokenService.delete(refreshToken);
             }
-
-            refreshTokenService.delete(refreshToken);
-
+        } catch (BaseException e) {
+            handleException(response);
+            return;
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private void handleException(HttpServletResponse response) throws IOException {
+        CookieUtil.deleteCookie(response, jwtTokenService.getTokenName());
+        CookieUtil.deleteCookie(response, refreshTokenService.getTokenName());
+        SecurityContextHolder.clearContext();
+
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write(
+                new ObjectMapper().writeValueAsString(
+                        BaseResponse.error(BaseResponseStatus.INVALID_REFRESH_TOKEN)
+                )
+        );
     }
 }

--- a/src/main/java/com/halo/core_bridge/api/token/filter/JwtAuthFilter.java
+++ b/src/main/java/com/halo/core_bridge/api/token/filter/JwtAuthFilter.java
@@ -1,0 +1,130 @@
+package com.halo.core_bridge.api.token.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.core_bridge.api.token.jwt.JwtTokenService;
+import com.halo.core_bridge.api.token.refresh.model.dto.RefreshTokenDto;
+import com.halo.core_bridge.api.token.refresh.service.RefreshTokenService;
+import com.halo.core_bridge.api.users.model.dto.UserDto;
+import com.halo.core_bridge.common.model.BaseResponse;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
+import com.halo.core_bridge.utils.CookieUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final RefreshTokenService refreshTokenService;
+    private final JwtTokenService jwtTokenService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String accessToken = null;
+        String refreshToken = null;
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            accessToken = CookieUtil.getCookieValue(request, jwtTokenService.getTokenName());
+            refreshToken = CookieUtil.getCookieValue(request, refreshTokenService.getTokenName());
+        }
+
+        if (accessToken != null) {
+
+            try {
+
+                UserDto.Auth userAuth = jwtTokenService.toUserAuth(accessToken);
+                // Authentication 객체 생성
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        userAuth,
+                        null,
+                        List.of(new SimpleGrantedAuthority(userAuth.getRole()))
+                );
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            } catch (ExpiredJwtException e) {
+                // 유효기간 만료시 재발급
+                log.error("AccessToken 만료, RefreshToken 사용하여 AccessToken 재발급 시도");
+
+                if (refreshToken != null) {
+
+                    // RefreshToken 검증
+                    RefreshTokenDto.Meta refreshTokenMeta = refreshTokenService.validateAndGetMeta(refreshToken);
+
+                    // AccessToken 재발급
+                    String reIssuedAccessToken = jwtTokenService.generateToken(refreshTokenMeta.getUserId(), refreshTokenMeta.getRole());
+
+                    // AccessToken 재발급이 성공하면 RefreshToken Rotation
+                    if (reIssuedAccessToken != null) {
+
+                        // RefreshToken Rotation
+                        String reIssuedRefreshToken = refreshTokenService.rotation(refreshToken);
+
+                        // AccessToken, RefreshToken Cookie 생성
+
+                        CookieUtil.addAccessTokenCookie(response, reIssuedAccessToken, jwtTokenService.getTokenName(), jwtTokenService.getExpiration());
+                        CookieUtil.addRefreshTokenCookie(response, reIssuedRefreshToken, refreshTokenService.getTokenName(), refreshTokenService.getExpiration());
+
+                        handleSuccessReIssueToken(response);
+                        return;
+                    }
+                }
+
+                log.error("재발급 실패, 로그아웃 처리 됩니다.");
+                handleTokenException(response, BaseResponseStatus.EXCEPTION_CREATE_ACCESS_TOKEN);
+                return;
+
+            } catch (Exception e) {
+
+                log.error("토큰 예외 발생, 로그아웃 처리 됩니다.");
+                log.error(e.getMessage());
+                handleTokenException(response, BaseResponseStatus.INVALID_JWT);
+                return;
+
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void handleSuccessReIssueToken(HttpServletResponse response) throws IOException {
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.getWriter().write(
+                new ObjectMapper().writeValueAsString(
+                        BaseResponse.success("토큰 재발급 성공")
+                )
+        );
+    }
+
+    private void handleTokenException(HttpServletResponse response, BaseResponseStatus status) throws IOException {
+
+        // 쿠키 삭제
+        CookieUtil.deleteCookie(response, jwtTokenService.getTokenName());
+        CookieUtil.deleteCookie(response, refreshTokenService.getTokenName());
+
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write(
+                new ObjectMapper().writeValueAsString(
+                        BaseResponse.error(status)
+                )
+        );
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/token/filter/JwtAuthFilter.java
+++ b/src/main/java/com/halo/core_bridge/api/token/filter/JwtAuthFilter.java
@@ -118,6 +118,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         // 쿠키 삭제
         CookieUtil.deleteCookie(response, jwtTokenService.getTokenName());
         CookieUtil.deleteCookie(response, refreshTokenService.getTokenName());
+        SecurityContextHolder.clearContext();
 
         response.setContentType("application/json; charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);

--- a/src/main/java/com/halo/core_bridge/api/token/filter/LoginFilter.java
+++ b/src/main/java/com/halo/core_bridge/api/token/filter/LoginFilter.java
@@ -10,6 +10,7 @@ import com.halo.core_bridge.common.model.BaseResponse;
 import com.halo.core_bridge.common.model.BaseResponseStatus;
 import com.halo.core_bridge.utils.CookieUtil;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import java.io.IOException;
@@ -76,6 +78,26 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         }
 
         throw BaseException.from(BaseResponseStatus.EXCEPTION_CREATE_ACCESS_TOKEN);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request,
+                                              HttpServletResponse response,
+                                              AuthenticationException failed) throws IOException, ServletException {
+
+        log.error(failed.getMessage());
+
+        CookieUtil.deleteCookie(response, refreshTokenService.getTokenName());
+        CookieUtil.deleteCookie(response, jwtTokenService.getTokenName());
+        SecurityContextHolder.clearContext();
+
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write(
+                new ObjectMapper().writeValueAsString(
+                        BaseResponse.error(BaseResponseStatus.INVALID_USER_INFO)
+                )
+        );
     }
 
     private void createRefreshTokenCookie(HttpServletResponse response, Long userId, String role) {

--- a/src/main/java/com/halo/core_bridge/api/token/filter/LoginFilter.java
+++ b/src/main/java/com/halo/core_bridge/api/token/filter/LoginFilter.java
@@ -1,0 +1,87 @@
+package com.halo.core_bridge.api.token.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.core_bridge.api.token.jwt.JwtTokenService;
+import com.halo.core_bridge.api.token.refresh.model.dto.RefreshTokenDto;
+import com.halo.core_bridge.api.token.refresh.service.RefreshTokenService;
+import com.halo.core_bridge.api.users.model.dto.UserDto;
+import com.halo.core_bridge.common.exception.BaseException;
+import com.halo.core_bridge.common.model.BaseResponse;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
+import com.halo.core_bridge.utils.CookieUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final RefreshTokenService refreshTokenService;
+    private final JwtTokenService jwtTokenService;
+    private final AuthenticationManager authenticationManager;
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        UsernamePasswordAuthenticationToken authToken;
+        try {
+
+            UserDto.Login dto = new ObjectMapper().readValue(request.getInputStream(), UserDto.Login.class);
+            authToken = new UsernamePasswordAuthenticationToken(
+                    dto.getEmail(), dto.getPassword(), null
+            );
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return authenticationManager.authenticate(authToken);
+    }
+
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException {
+
+        UserDto.Auth authUser = (UserDto.Auth) authResult.getPrincipal();
+
+        String accessToken = jwtTokenService.generateToken(
+                authUser.getId(),
+                authUser.getRole()
+        );
+
+        if(accessToken != null) {
+            log.info("AccessToken 발급 성공");
+
+            createRefreshTokenCookie(response, authUser.getId(), authUser.getRole());
+            CookieUtil.addAccessTokenCookie(response, accessToken, jwtTokenService.getTokenName(), jwtTokenService.getExpiration());
+
+            response.setContentType("application/json; charset=UTF-8");
+
+            response.getWriter().write(
+                    new ObjectMapper().writeValueAsString(
+                            BaseResponse.success(null)
+                    )
+            );
+
+            return;
+        }
+
+        throw BaseException.from(BaseResponseStatus.EXCEPTION_CREATE_ACCESS_TOKEN);
+    }
+
+    private void createRefreshTokenCookie(HttpServletResponse response, Long userId, String role) {
+        log.info("RefreshToken 발급 진행");
+
+        String generatedToken = refreshTokenService.generateRefreshToken(RefreshTokenDto.Meta.from(userId, role));
+        CookieUtil.addRefreshTokenCookie(response, generatedToken, refreshTokenService.getTokenName(), refreshTokenService.getExpiration());
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/token/jwt/JwtTokenService.java
+++ b/src/main/java/com/halo/core_bridge/api/token/jwt/JwtTokenService.java
@@ -1,0 +1,80 @@
+package com.halo.core_bridge.api.token.jwt;
+
+import com.halo.core_bridge.api.users.model.dto.UserDto;
+import com.halo.core_bridge.common.exception.BaseException;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+    private final SecretKeyManager secretKeyManager;
+
+    @Getter
+    @Value("${app.token.access.name}")
+    private String tokenName;
+
+    @Getter
+    @Value("${app.token.access.expiration}")
+    private Long expiration;
+
+    private final String id = "id";
+    private final String role = "role";
+
+    public String generateToken(Long id, String role) {
+
+        Map<String, String> claims =  new HashMap<>();
+        claims.put(this.id, String.valueOf(id));
+        claims.put(this.role, role);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getSecretKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private String getValue(Claims claims, String key) {
+        return (String) claims.get(key);
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSecretKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public UserDto.Auth toUserAuth(String token) {
+        Claims claims = getClaims(token);
+
+        String id = getValue(claims, this.id);
+        String role = getValue(claims, this.role);
+
+        if (id == null || role == null) {
+            throw BaseException.from(BaseResponseStatus.INVALID_JWT);
+        }
+
+        return UserDto.Auth.builder()
+                .id(Long.parseLong(id))
+                .role(role)
+                .build();
+    }
+
+    private SecretKey getSecretKey() {
+        return secretKeyManager.getSecretKey();
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/token/jwt/SecretKeyManager.java
+++ b/src/main/java/com/halo/core_bridge/api/token/jwt/SecretKeyManager.java
@@ -1,0 +1,32 @@
+package com.halo.core_bridge.api.token.jwt;
+
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+
+@Component
+public class SecretKeyManager {
+
+    @Value("${app.token.access.secretKey}")
+    private String secretKeyPlain;
+
+    private SecretKey encodedSecretKey;
+
+    @PostConstruct
+    public void init() {
+        encodedSecretKey = createSecretKey();
+    }
+
+    private SecretKey createSecretKey() {
+        String keyBase64Encoded = Base64.getEncoder().encodeToString(secretKeyPlain.getBytes());
+        return Keys.hmacShaKeyFor(keyBase64Encoded.getBytes());
+    }
+
+    public SecretKey getSecretKey() {
+        return encodedSecretKey;
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/token/refresh/model/dto/RefreshTokenDto.java
+++ b/src/main/java/com/halo/core_bridge/api/token/refresh/model/dto/RefreshTokenDto.java
@@ -1,0 +1,26 @@
+package com.halo.core_bridge.api.token.refresh.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RefreshTokenDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Meta {
+
+        private Long userId;
+        private String role;
+
+        public static Meta from(Long userId, String role) {
+            return Meta.builder()
+                    .userId(userId)
+                    .role(role)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/token/refresh/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/token/refresh/repository/RefreshTokenRepository.java
@@ -1,0 +1,63 @@
+package com.halo.core_bridge.api.token.refresh.repository;
+
+import com.halo.core_bridge.api.token.refresh.model.dto.RefreshTokenDto;
+import com.halo.core_bridge.common.exception.BaseException;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+
+    private final String prefix = "RT:";
+
+    @Getter
+    @Value("${app.token.refresh.expiration}")
+    private Long expiration;
+
+    private final RedisTemplate<String, RefreshTokenDto.Meta> redisTemplate;
+
+    /**
+     * RefreshToken을 저장한다.
+     * @param token 저장할 RefreshToken
+     * @param refreshTokenMeta RefreshToken과 함께 value로 저장될 MetaData
+     */
+    public void save(String token, RefreshTokenDto.Meta refreshTokenMeta) {
+        redisTemplate.opsForValue().set(prefix + token, refreshTokenMeta, Duration.ofMillis(expiration));
+    }
+
+    /**
+     * RefreshToken을 사용해 <code>value</code>값을 찾는다.
+     * @param refreshToken key로 사용할 RefreshToken
+     * @return <code>RefreshTokenDto.Meta</code> value 값으로 저장된 MetaData
+     * @throws BaseException RefreshToken으로 조회한 value가 null인 경우 <code>BaseResponseStatus.INVALID_REFRESH_TOKEN</code> 예외 발생
+     */
+    public RefreshTokenDto.Meta findByKey(String refreshToken) {
+        RefreshTokenDto.Meta findMeta = redisTemplate.opsForValue().get(prefix + refreshToken);
+
+        if (findMeta == null) {
+            throw BaseException.from(BaseResponseStatus.INVALID_REFRESH_TOKEN);
+        }
+
+        return findMeta;
+    }
+
+    /**
+     * RefreshToken을 삭제한다.
+     * @param refreshToken 삭제할 RefreshToken
+     * @throws BaseException 삭제 결과가 false라면 <code>BaseResponseStatus.INVALID_REFRESH_TOKEN</code> 예외 발생
+     */
+    public void deleteByKey(String refreshToken) {
+        Boolean deleteResult = redisTemplate.delete(prefix + refreshToken);
+
+        if (Boolean.FALSE.equals(deleteResult)) {
+            throw BaseException.from(BaseResponseStatus.INVALID_REFRESH_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/token/refresh/service/RefreshTokenService.java
+++ b/src/main/java/com/halo/core_bridge/api/token/refresh/service/RefreshTokenService.java
@@ -1,0 +1,75 @@
+package com.halo.core_bridge.api.token.refresh.service;
+
+import com.halo.core_bridge.api.token.refresh.model.dto.RefreshTokenDto;
+import com.halo.core_bridge.api.token.refresh.repository.RefreshTokenRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Getter
+    @Value("${app.token.refresh.name}")
+    private String tokenName;
+
+    /**
+     * RefreshToken을 생성한다.
+     * @param meta Repository에 저장될 RefreshToken의 MetaData
+     * @return 새로 생성된 RefreshToken
+     */
+    public String generateRefreshToken(RefreshTokenDto.Meta meta) {
+        String refreshToken = UUID.randomUUID().toString();
+
+        refreshTokenRepository.save(refreshToken, meta);
+        return refreshToken;
+    }
+
+    /**
+     * RefreshToken을 검증하고 MeataData를 반환한다.
+     * @param refreshToken 검증할 RefreshToken
+     * @return <code>RefreshTokenDto.Meta</code>
+     */
+    public RefreshTokenDto.Meta validateAndGetMeta(String refreshToken) {
+        return refreshTokenRepository.findByKey(refreshToken);
+    }
+
+    /**
+     * 기존의 RefreshToken을 삭제하고 재발급하는 로테이션을 수행한다.
+     * @param oldRefreshToken 삭제할 RefreshToken
+     * @return 새로 생성된 RefreshToken
+     */
+    public String rotation(String oldRefreshToken) {
+
+        // 기존 리프레시토큰의 값을 가지고온다.
+        RefreshTokenDto.Meta findMeta = refreshTokenRepository.findByKey(oldRefreshToken);
+
+        // 기존 리프레시토큰을 삭제한다.
+        refreshTokenRepository.deleteByKey(oldRefreshToken);
+
+        // 새로운 리프레시토큰을 생성한다.
+        return generateRefreshToken(findMeta);
+    }
+
+    /**
+     * RefreshToken을 삭제한다.
+     * @param refreshToken 삭제할 RefreshToken
+     */
+    public void delete(String refreshToken) {
+        refreshTokenRepository.deleteByKey(refreshToken);
+    }
+
+    /**
+     * RefreshToken의 Expiration을 조회한다.
+     * @return <code>Long</code>
+     */
+    public Long getExpiration() {
+        return refreshTokenRepository.getExpiration();
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/users/model/dto/UserDto.java
+++ b/src/main/java/com/halo/core_bridge/api/users/model/dto/UserDto.java
@@ -4,11 +4,18 @@ import com.halo.core_bridge.api.users.model.Gender;
 import com.halo.core_bridge.api.users.model.entity.User;
 import com.halo.core_bridge.api.users.model.entity.UserRole;
 import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
 
 public class UserDto {
 
@@ -54,5 +61,43 @@ public class UserDto {
                     )
                     .build();
         }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Auth implements UserDetails {
+
+        private Long id;
+        private String email;
+        private String password;
+        private String name;
+        private String role;
+
+        @Override
+        public Collection<? extends GrantedAuthority> getAuthorities() {
+            return List.of(new SimpleGrantedAuthority(role));
+        }
+
+        @Override
+        public String getPassword() {
+            return password;
+        }
+
+        @Override
+        public String getUsername() {
+            return email;
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Login {
+
+        private String email;
+        private String password;
     }
 }

--- a/src/main/java/com/halo/core_bridge/api/users/repository/UserRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/users/repository/UserRepository.java
@@ -2,7 +2,14 @@ package com.halo.core_bridge.api.users.repository;
 
 import com.halo.core_bridge.api.users.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
+
+    @Query("select u from User u join fetch u.userRole ur where u.email = :email")
+    Optional<User> findByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/halo/core_bridge/api/users/service/CustomUserDetailsService.java
+++ b/src/main/java/com/halo/core_bridge/api/users/service/CustomUserDetailsService.java
@@ -3,6 +3,7 @@ package com.halo.core_bridge.api.users.service;
 import com.halo.core_bridge.api.users.model.dto.UserDto;
 import com.halo.core_bridge.api.users.model.entity.User;
 import com.halo.core_bridge.api.users.repository.UserRepository;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -35,6 +36,6 @@ public class CustomUserDetailsService implements UserDetailsService {
                     .build();
         }
 
-        return null;
+        throw new UsernameNotFoundException(BaseResponseStatus.INVALID_USER_INFO.getMessage());
     }
 }

--- a/src/main/java/com/halo/core_bridge/api/users/service/CustomUserDetailsService.java
+++ b/src/main/java/com/halo/core_bridge/api/users/service/CustomUserDetailsService.java
@@ -1,0 +1,40 @@
+package com.halo.core_bridge.api.users.service;
+
+import com.halo.core_bridge.api.users.model.dto.UserDto;
+import com.halo.core_bridge.api.users.model.entity.User;
+import com.halo.core_bridge.api.users.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Optional<User> findUser = userRepository.findByEmail(username);
+
+        if (findUser.isPresent()) {
+
+            User user = findUser.get();
+
+            return UserDto.Auth.builder()
+                    .id(user.getId())
+                    .email(user.getEmail())
+                    .password(user.getPassword())
+                    .name(user.getName())
+                    .role(user.getUserRole().getCode())
+                    .build();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/halo/core_bridge/common/model/BaseResponseStatus.java
+++ b/src/main/java/com/halo/core_bridge/common/model/BaseResponseStatus.java
@@ -29,7 +29,9 @@ public enum BaseResponseStatus {
     REQUEST_ERROR(false, 30001, "입력값을 확인해주세요."),
     INVALID_AUTH_CODE(false, 30002, "유효하지 않은 인증번호 입니다."),
     EXPIRED_JWT(false, 30008, "JWT 토큰이 만료되었습니다."),
-
+    JSON_PARSER(false, 30009 , "JSON Parsing 실패"),
+    INVALID_REFRESH_TOKEN(false, 30010, "유효하지 않는 토큰입니다."),
+    EXCEPTION_CREATE_ACCESS_TOKEN(false, 30011, "토큰 생성 중 예기지 못한 오류가 발생하였습니다."),
     /**
      * 40000 : Response 오류
      */
@@ -45,7 +47,6 @@ public enum BaseResponseStatus {
      * 60000 : Server 오류
      */
     SERVER_ERROR(false, 60001, "서버와의 연결에 실패하였습니다.");
-
 
 
     /**

--- a/src/main/java/com/halo/core_bridge/config/RedisConfig.java
+++ b/src/main/java/com/halo/core_bridge/config/RedisConfig.java
@@ -1,13 +1,15 @@
 package com.halo.core_bridge.config;
 
+import com.halo.core_bridge.api.token.refresh.model.dto.RefreshTokenDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.listener.ChannelTopic;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -28,5 +30,20 @@ public class RedisConfig {
         StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
         stringRedisTemplate.setConnectionFactory(connectionFactory);
         return stringRedisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, RefreshTokenDto.Meta> refreshTokenRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, RefreshTokenDto.Meta> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        redisTemplate.afterPropertiesSet();
+        return redisTemplate;
     }
 }

--- a/src/main/java/com/halo/core_bridge/config/SecurityConfig.java
+++ b/src/main/java/com/halo/core_bridge/config/SecurityConfig.java
@@ -1,7 +1,14 @@
 package com.halo.core_bridge.config;
 
+import com.halo.core_bridge.api.token.filter.AlreadyLoginFilter;
+import com.halo.core_bridge.api.token.filter.JwtAuthFilter;
+import com.halo.core_bridge.api.token.filter.LoginFilter;
+import com.halo.core_bridge.api.token.jwt.JwtTokenService;
+import com.halo.core_bridge.api.token.refresh.service.RefreshTokenService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -9,10 +16,16 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final RefreshTokenService refreshTokenService;
+    private final JwtTokenService jwtTokenService;
 
     @Bean
     public SecurityFilterChain configure(HttpSecurity http) throws Exception {
@@ -31,11 +44,24 @@ public class SecurityConfig {
 
         http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
+        addFilter(http);
+
         return http.build();
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    private void addFilter(HttpSecurity http) throws Exception {
+
+        JwtAuthFilter jwtAuthFilter = new JwtAuthFilter(refreshTokenService, jwtTokenService);
+        AlreadyLoginFilter alreadyLoginFilter = new AlreadyLoginFilter(refreshTokenService, jwtTokenService);
+        LoginFilter loginFilter = new LoginFilter(refreshTokenService, jwtTokenService, authenticationConfiguration.getAuthenticationManager());
+
+        http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterAfter(alreadyLoginFilter, JwtAuthFilter.class);
+        http.addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class);
     }
 }

--- a/src/main/java/com/halo/core_bridge/utils/CookieUtil.java
+++ b/src/main/java/com/halo/core_bridge/utils/CookieUtil.java
@@ -1,0 +1,65 @@
+package com.halo.core_bridge.utils;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.Arrays;
+
+public class CookieUtil {
+
+    @Value("${app.cookie.secure}")
+    private static boolean cookieSecure;
+
+    public static void createCookie(HttpServletResponse response,
+                              String cookieName,
+                              String cookieValue,
+                              boolean httpOnly,
+                              String path,
+                              int expire) {
+
+        Cookie cookie = new Cookie(cookieName, cookieValue);
+        cookie.setHttpOnly(httpOnly);
+        cookie.setPath(path);
+        cookie.setMaxAge(expire);
+        cookie.setSecure(cookieSecure);
+
+        response.addCookie(cookie);
+    }
+
+    public static void addRefreshTokenCookie(HttpServletResponse response, String refreshToken, String cookieName, Long expire) {
+        addAccessTokenCookie(response, refreshToken, cookieName,expire);
+    }
+
+    public static void addAccessTokenCookie(HttpServletResponse response, String accessToken, String cookieName, Long expire) {
+        int exp = convertLongToIntSecond(expire);
+        createCookie(response, cookieName, accessToken, cookieSecure, "/", exp);
+    }
+
+    public static String getCookieValue(HttpServletRequest request, String cookieName) {
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            return Arrays.stream(request.getCookies())
+                    .filter(cookie -> cookie.getName().equals(cookieName))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        return null;
+    }
+
+    public static void deleteCookie(HttpServletResponse response, String cookieName) {
+        Cookie cookie = new Cookie(cookieName, null);
+        cookie.setMaxAge(0);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+    }
+
+    private static int convertLongToIntSecond(Long value) {
+        return Math.toIntExact(value) / 1000;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,3 +15,7 @@ spring:
     init:
       mode: always
       data-locations: classpath:db/data.sql
+
+app:
+  cookie:
+    secure: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,3 +15,7 @@ spring:
     init:
       mode: never
       data-locations: classpath:db/data.sql
+
+app:
+  cookie:
+    secure: true

--- a/src/main/resources/application-token.yml
+++ b/src/main/resources/application-token.yml
@@ -1,0 +1,10 @@
+app:
+  token:
+    access:
+      name: ${ACCESS_TOKEN_NAME}
+      expiration: ${ACCESS_TOKEN_EXPIRATION}
+      secretKey: ${ACCESS_TOKEN_SECRET_KEY}
+
+    refresh:
+      name: ${REFRESH_TOKEN_NAME}
+      expiration: ${REFRESH_TOKEN_EXPIRATION}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
   profiles:
     active: dev
 
+  config:
+    import:
+      - "classpath:application-token.yml"
+
   datasource:
     url: ${DB_URL}
     driver-class-name: org.mariadb.jdbc.Driver


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closes #이슈번호, closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!

closes #44

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 이메일과 비밀번호를 요청받아 로그인을 수행하도록 구현
2. 로그인에 성공했다면 AccessToken, RefreshToken을 쿠키에 담아 전송하도록 구현
3. AccessToken의 만료시간을 15분 정도로 짧게 주어 RefreshToken을 사용해 재발급받을 수 있도록 구현
4. RefreshToken은 일회성으로 간주하고 AccessToken을 재발급 할 때, 동시에 RefreshToken도 재발급 되도록 구현(RTR)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
