### PR TITLE
feat: 비밀번호 분실 시 재설정 기능 구현

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/auth/controller/UserFindController.java
+++ b/src/main/java/com/halo/core_bridge/api/auth/controller/UserFindController.java
@@ -1,0 +1,29 @@
+package com.halo.core_bridge.api.auth.controller;
+
+import com.halo.core_bridge.api.auth.model.AuthDto;
+import com.halo.core_bridge.api.mail.service.PasswordResetMailService;
+import com.halo.core_bridge.common.model.BaseResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name ="아이디와 비밀번호 찾기 기능")
+public class UserFindController {
+
+    private final PasswordResetMailService passwordResetMailService;
+
+    @PostMapping("/find-password/link")
+    public ResponseEntity<BaseResponse<Object>> sendAuthCodeForResetPassword(@RequestBody AuthDto.SendEmail emailForPwdRest) {
+        String email = emailForPwdRest.getEmail();
+        passwordResetMailService.sendToEmail(email);
+
+        return ResponseEntity.ok(BaseResponse.success("비밀번호 재설정 링크 전송 성공"));
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/auth/controller/UserFindController.java
+++ b/src/main/java/com/halo/core_bridge/api/auth/controller/UserFindController.java
@@ -1,6 +1,7 @@
 package com.halo.core_bridge.api.auth.controller;
 
 import com.halo.core_bridge.api.auth.model.AuthDto;
+import com.halo.core_bridge.api.auth.service.UserFindService;
 import com.halo.core_bridge.api.mail.service.PasswordResetMailService;
 import com.halo.core_bridge.common.model.BaseResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserFindController {
 
     private final PasswordResetMailService passwordResetMailService;
+    private final UserFindService userFindService;
 
     @PostMapping("/find-password/link")
     public ResponseEntity<BaseResponse<Object>> sendAuthCodeForResetPassword(@RequestBody AuthDto.SendEmail emailForPwdRest) {
@@ -25,5 +27,13 @@ public class UserFindController {
         passwordResetMailService.sendToEmail(email);
 
         return ResponseEntity.ok(BaseResponse.success("비밀번호 재설정 링크 전송 성공"));
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<BaseResponse<Object>> resetPassword(@RequestBody AuthDto.ResetPassword resetPassword) {
+
+        userFindService.resetPassword(resetPassword);
+
+        return ResponseEntity.ok(BaseResponse.success("재설정 성공"));
     }
 }

--- a/src/main/java/com/halo/core_bridge/api/auth/model/AuthDto.java
+++ b/src/main/java/com/halo/core_bridge/api/auth/model/AuthDto.java
@@ -1,0 +1,18 @@
+package com.halo.core_bridge.api.auth.model;
+
+import lombok.Getter;
+
+public class AuthDto {
+
+    @Getter
+    public static class SendEmail {
+        private String email;
+    }
+
+    @Getter
+    public static class ResetPassword {
+        private String email;
+        private String password;
+        private String token;
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/auth/model/AuthDto.java
+++ b/src/main/java/com/halo/core_bridge/api/auth/model/AuthDto.java
@@ -1,6 +1,9 @@
 package com.halo.core_bridge.api.auth.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class AuthDto {
 
@@ -10,6 +13,9 @@ public class AuthDto {
     }
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class ResetPassword {
         private String email;
         private String password;

--- a/src/main/java/com/halo/core_bridge/api/auth/service/AuthService.java
+++ b/src/main/java/com/halo/core_bridge/api/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.halo.core_bridge.api.auth.service;
 
 import com.halo.core_bridge.api.auth.model.AuthCodeMail;
+import com.halo.core_bridge.api.auth.model.AuthDto;
 import com.halo.core_bridge.api.mail.model.MailSend;
 import com.halo.core_bridge.common.exception.BaseException;
 import com.halo.core_bridge.common.model.BaseResponseStatus;
@@ -29,6 +30,28 @@ public class AuthService {
         }
 
         deleteByRedisKey(redisKey);
+    }
+
+    /**
+     * 비밀번호를 재설정 하기 전 올바른 인증 토큰인지 확인.
+     * @param uuid 인증이 필요한 토큰
+     * @return <code>AuthDto.ResetPassword</code>
+     * @throws BaseException 유효하지 않은 토큰인 경우 예외 발생
+     */
+    public AuthDto.ResetPassword verifyUserPasswordReset(String uuid) {
+
+        String redisKey = MailSend.PASSWORD_RESET_MAIL.createRedisKey(uuid);
+        String findEmail = getValue(redisKey);
+
+        if (findEmail == null) {
+            throw BaseException.from(BaseResponseStatus.INVALID_REFRESH_TOKEN);
+        }
+
+        deleteByRedisKey(redisKey);
+
+        return AuthDto.ResetPassword.builder()
+                .email(findEmail)
+                .build();
     }
 
     private String getValue(String redisKey) {

--- a/src/main/java/com/halo/core_bridge/api/auth/service/AuthService.java
+++ b/src/main/java/com/halo/core_bridge/api/auth/service/AuthService.java
@@ -34,24 +34,25 @@ public class AuthService {
 
     /**
      * 비밀번호를 재설정 하기 전 올바른 인증 토큰인지 확인.
-     * @param uuid 인증이 필요한 토큰
-     * @return <code>AuthDto.ResetPassword</code>
+     * @param resetPassword 비밀번호 재설정을 위한 DTO
      * @throws BaseException 유효하지 않은 토큰인 경우 예외 발생
      */
-    public AuthDto.ResetPassword verifyUserPasswordReset(String uuid) {
+    public void verifyUserPasswordReset(AuthDto.ResetPassword resetPassword) {
 
-        String redisKey = MailSend.PASSWORD_RESET_MAIL.createRedisKey(uuid);
-        String findEmail = getValue(redisKey);
+        String redisKey = MailSend.PASSWORD_RESET_MAIL.createRedisKey(resetPassword.getEmail());
+        String findUuidByEmail = getValue(redisKey);
 
-        if (findEmail == null) {
+        // redisKey로 조회한 값이 null이라면 예외 처리
+        if (findUuidByEmail == null) {
+            throw BaseException.from(BaseResponseStatus.INVALID_REFRESH_TOKEN);
+        }
+
+        // uuid가 일치하지 않는 경우 예외처리
+        if (!resetPassword.getToken().equals(findUuidByEmail)) {
             throw BaseException.from(BaseResponseStatus.INVALID_REFRESH_TOKEN);
         }
 
         deleteByRedisKey(redisKey);
-
-        return AuthDto.ResetPassword.builder()
-                .email(findEmail)
-                .build();
     }
 
     private String getValue(String redisKey) {

--- a/src/main/java/com/halo/core_bridge/api/auth/service/UserFindService.java
+++ b/src/main/java/com/halo/core_bridge/api/auth/service/UserFindService.java
@@ -1,0 +1,42 @@
+package com.halo.core_bridge.api.auth.service;
+
+import com.halo.core_bridge.api.auth.model.AuthDto;
+import com.halo.core_bridge.api.users.model.entity.User;
+import com.halo.core_bridge.api.users.repository.UserRepository;
+import com.halo.core_bridge.api.users.service.PasswordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserFindService {
+
+    private final UserRepository userRepository;
+    private final AuthService authService;
+    private final PasswordService passwordService;
+
+    /**
+     * 비밀번호를 초기화 한다.
+     * @param resetPassword
+     */
+    @Transactional
+    public void resetPassword(AuthDto.ResetPassword resetPassword) {
+        String newPassword = resetPassword.getPassword();
+
+        String token = resetPassword.getToken();
+
+        AuthDto.ResetPassword findEmail = authService.verifyUserPasswordReset(token);
+
+        Optional<User> result = userRepository.findByEmail(findEmail.getEmail());
+
+        if (result.isEmpty()) {
+            throw new IllegalArgumentException("유효하지 않은 이메일");
+        }
+
+        User findUser = result.get();
+        passwordService.changePassword(findUser, newPassword);
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/auth/service/UserFindService.java
+++ b/src/main/java/com/halo/core_bridge/api/auth/service/UserFindService.java
@@ -4,6 +4,8 @@ import com.halo.core_bridge.api.auth.model.AuthDto;
 import com.halo.core_bridge.api.users.model.entity.User;
 import com.halo.core_bridge.api.users.repository.UserRepository;
 import com.halo.core_bridge.api.users.service.PasswordService;
+import com.halo.core_bridge.common.exception.BaseException;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,20 +22,18 @@ public class UserFindService {
 
     /**
      * 비밀번호를 초기화 한다.
-     * @param resetPassword
+     * @param resetPassword 비밀번호 재설정 DTO
      */
     @Transactional
     public void resetPassword(AuthDto.ResetPassword resetPassword) {
         String newPassword = resetPassword.getPassword();
 
-        String token = resetPassword.getToken();
+        authService.verifyUserPasswordReset(resetPassword);
 
-        AuthDto.ResetPassword findEmail = authService.verifyUserPasswordReset(token);
-
-        Optional<User> result = userRepository.findByEmail(findEmail.getEmail());
+        Optional<User> result = userRepository.findByEmail(resetPassword.getEmail());
 
         if (result.isEmpty()) {
-            throw new IllegalArgumentException("유효하지 않은 이메일");
+            throw BaseException.from(BaseResponseStatus.NOT_FOUND_USER);
         }
 
         User findUser = result.get();

--- a/src/main/java/com/halo/core_bridge/api/mail/model/MailSend.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/model/MailSend.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MailSend {
-    AUTH_CODE_MAIL("[CoreBridge] 안녕하세요. 요청하신 인증번호를 보내드립니다.", "AUTH_CODE_MAIL:");
+    AUTH_CODE_MAIL("[CoreBridge] 안녕하세요. 요청하신 인증번호를 보내드립니다.", "AUTH_CODE_MAIL:"),
+    PASSWORD_RESET_MAIL("[CoreBridge] 안녕하세요. 요청하신 비밀번호 재설정 링크를 보내드립니다.", "PASSWORD_RESET_MAIL:");
 
     private final String subject;
     private final String keyName;

--- a/src/main/java/com/halo/core_bridge/api/mail/service/PasswordResetMailService.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/service/PasswordResetMailService.java
@@ -1,0 +1,73 @@
+package com.halo.core_bridge.api.mail.service;
+
+import com.halo.core_bridge.api.mail.model.MailSend;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+public class PasswordResetMailService extends BaseMailService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${password.reset.redirect.url}")
+    private String REDIRECT_LINK;
+    private String uuid;
+
+    public PasswordResetMailService(JavaMailSender mailSender, StringRedisTemplate redisTemplate) {
+        super(mailSender, MailSend.PASSWORD_RESET_MAIL.getSubject());
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void sendToEmail(String email) {
+        uuid = createUuid();
+        MimeMessage mimeMessage = createMimeMessage(email);
+
+        redisTemplate.opsForValue().set(createRedisKey(), email, Duration.ofMinutes(5));
+
+        mailSender.send(mimeMessage);
+    }
+
+    @Override
+    protected String createView() {
+        String rawView = """
+                 <html>
+                     <head>
+                     </head>
+                 <body>
+                     <p>
+                         안녕하세요.<br>
+                         저희 <b>CoreBridge</b>을 이용해 주셔서 감사합니다.<br>
+                         비밀번호 재설정 링크를 보내드립니다.
+                         아래의 링크에 접속하여 비밀번호를 재설정해주세요.
+                     </p>
+                 <strong style="font-size:20px">
+                     <a href="%s"> 비밀번호 재설정 바로가기 </a>
+                 </strong>
+                     <p>
+                         <font size=3><b>개인정보 보호를 위해서 링크는 5분간 유지됩니다.</b></font>
+                     </p>
+                 </body>
+                 </html>
+                """;
+        return String.format(rawView, createURI(uuid));
+    }
+
+    private String createUuid() {
+        return UUID.randomUUID().toString();
+    }
+
+    private String createURI(String uuid) {
+        return REDIRECT_LINK.concat("?token=").concat(uuid);
+    }
+
+    private String createRedisKey() {
+        return MailSend.PASSWORD_RESET_MAIL.createRedisKey(uuid);
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/mail/service/PasswordResetMailService.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/service/PasswordResetMailService.java
@@ -29,7 +29,7 @@ public class PasswordResetMailService extends BaseMailService {
         uuid = createUuid();
         MimeMessage mimeMessage = createMimeMessage(email);
 
-        redisTemplate.opsForValue().set(createRedisKey(), email, Duration.ofMinutes(5));
+        redisTemplate.opsForValue().set(createRedisKey(email), uuid, Duration.ofMinutes(5));
 
         mailSender.send(mimeMessage);
     }
@@ -67,7 +67,7 @@ public class PasswordResetMailService extends BaseMailService {
         return REDIRECT_LINK.concat("?token=").concat(uuid);
     }
 
-    private String createRedisKey() {
-        return MailSend.PASSWORD_RESET_MAIL.createRedisKey(uuid);
+    private String createRedisKey(String email) {
+        return MailSend.PASSWORD_RESET_MAIL.createRedisKey(email);
     }
 }

--- a/src/main/java/com/halo/core_bridge/api/users/service/PasswordService.java
+++ b/src/main/java/com/halo/core_bridge/api/users/service/PasswordService.java
@@ -16,4 +16,8 @@ public class PasswordService {
 
         entity.updatePassword(encodedPassword);
     }
+
+    public void changePassword(User entity, String newPassword) {
+        this.encodePassword(entity, newPassword);
+    }
 }

--- a/src/main/java/com/halo/core_bridge/common/model/BaseResponseStatus.java
+++ b/src/main/java/com/halo/core_bridge/common/model/BaseResponseStatus.java
@@ -24,6 +24,7 @@ public enum BaseResponseStatus {
     INVALID_USER_INFO(false,20004,"이메일 또는 비밀번호를 확인해주세요."),
     INVALID_USER_DISABLED(false,20005,"이메일 인증이 필요합니다. 이메일을 확인해주세요."),
     DUPLICATE_USER_EMAIL(false,20006,"중복된 이메일입니다. 다른 이메일을 사용해주세요."),
+    NOT_FOUND_USER(false, 20007, "존재하지 않는 사용자입니다."),
 
     GLOBAL_EXCEPTION(false, 30000, "요청을 처리하는 과정에서 문제가 발생하였습니다."),
     REQUEST_ERROR(false, 30001, "입력값을 확인해주세요."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,8 @@ spring:
 redis:
   host: ${REDIS_HOST}
   port: ${REDIS_PORT}
+
+password:
+  reset:
+    redirect:
+      url: ${PWD_RESET_REDIRECT_URL}

--- a/src/test/java/com/halo/core_bridge/api/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/halo/core_bridge/api/auth/service/AuthServiceTest.java
@@ -46,7 +46,7 @@ class AuthServiceTest {
         given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(any(String.class))).willReturn("123456");
 
-        willDoNothing().given(userService).existByEmail(any(String.class));
+//        willDoNothing().given(userService).existByEmail(any(String.class));
 
         // when
         // then
@@ -65,7 +65,7 @@ class AuthServiceTest {
         given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(any(String.class))).willReturn("123456");
 
-        willDoNothing().given(userService).existByEmail(any(String.class));
+//        willDoNothing().given(userService).existByEmail(any(String.class));
 
         // when
         // then


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closes #이슈번호, closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!

closes #1

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 비밀번호를 잊은 사용자가 비밀번호를 초기화 하는 기능을 구현
* 이메일을 입력하고 요청을 하면 이메일로 비밀번호 변경 링크가 전송되고 해당 링크에 접속하여 비밀번호를 재설정할 수 있다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
