### PR TITLE
feat: Redis와 SSE를 이용한 alarm 기능 추가

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/schedule/jobposting/service/JobPostingScheduleService.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/jobposting/service/JobPostingScheduleService.java
@@ -5,6 +5,8 @@ import com.halo.core_bridge.api.jobposting.repository.JobPostingRepository;
 import com.halo.core_bridge.api.schedule.jobposting.model.dto.JobPostingScheduleDto;
 import com.halo.core_bridge.api.schedule.jobposting.model.entity.JobPostingSchedule;
 import com.halo.core_bridge.api.schedule.jobposting.repository.JobPostingScheduleRepository;
+import com.halo.core_bridge.api.schedule.notification.model.enums.NotificationType;
+import com.halo.core_bridge.api.schedule.notification.service.NotificationService;
 import com.halo.core_bridge.common.exception.BaseException;
 import com.halo.core_bridge.common.model.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,7 @@ public class JobPostingScheduleService {
     private static final String[] DEFAULT_COLORS = {"#60A5FA", "#34D399", "#F472B6", "#FBBF24", "#A78BFA", "#F87171"};
     private final JobPostingScheduleRepository jobScheduleRepository;
     private final JobPostingRepository jobPostingRepository;
+    private final NotificationService notificationService;
 
     public List<JobPostingScheduleDto.Response> getAll() {
         log.info("[JobScheduleService] getAll");
@@ -59,7 +62,13 @@ public class JobPostingScheduleService {
                 if (firstSaved == null) firstSaved = s;
             }
         }
-
+        notificationService.publishNotification(
+                1L,
+                NotificationType.JOB_SCHEDULE_CREATED,
+                "새로운 채용 일정이 추가되었습니다.",
+                jobPosting.getTitle(),
+                "/recruiter/jobs/" + jobPosting.getId() + "/schedule"
+        );
         return firstSaved.toDto();
     }
 
@@ -71,6 +80,13 @@ public class JobPostingScheduleService {
         String color = resolveColor(request.getColor(), schedule.getJobPosting().getId());
         schedule.update(request, color);
 
+        notificationService.publishNotification(
+                1L,
+                NotificationType.JOB_SCHEDULE_UPDATED,
+                "공고 일정이 수정되었습니다: " + schedule.getTitle(),
+                schedule.getJobPosting().getTitle(),
+                "/recruiter/jobs/" + schedule.getJobPosting().getId() + "/schedule"
+        );
         return schedule.toDto();
     }
 
@@ -84,6 +100,14 @@ public class JobPostingScheduleService {
         } else {
             jobScheduleRepository.delete(schedule);
         }
+
+        notificationService.publishNotification(
+                1L,
+                NotificationType.JOB_SCHEDULE_DELETED,
+                "공고 일정이 삭제되었습니다: " + schedule.getTitle(),
+                schedule.getJobPosting().getTitle(),
+                "/recruiter/jobs/" + schedule.getJobPosting().getId() + "/schedule"
+        );
     }
 
     private JobPosting validateJobPostingExists(Long jobPostingId) {

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/controller/NotificationSseController.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/controller/NotificationSseController.java
@@ -1,0 +1,23 @@
+package com.halo.core_bridge.api.schedule.notification.controller;
+
+import com.halo.core_bridge.api.schedule.notification.service.NotificationSseEmitterService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationSseController {
+    private final NotificationSseEmitterService sseService;
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@RequestParam(name = "userId", required = false) Long userId) {
+        if (userId == null) userId = 1L; // TODO 여기 수정
+        return sseService.subscribe(userId);
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/model/dto/NotificationPayload.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/model/dto/NotificationPayload.java
@@ -1,0 +1,15 @@
+package com.halo.core_bridge.api.schedule.notification.model.dto;
+
+import com.halo.core_bridge.api.schedule.notification.model.enums.NotificationType;
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class NotificationPayload {
+    private Long userId;
+    private NotificationType type;
+    private String title;
+    private String message;
+    private String jobTitle; // optional
+    private String link;     // optional
+    private long timestamp;
+}

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/model/enums/NotificationType.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/model/enums/NotificationType.java
@@ -1,0 +1,11 @@
+package com.halo.core_bridge.api.schedule.notification.model.enums;
+
+public enum NotificationType {
+    SYSTEM,
+    JOB_SCHEDULE_CREATED,
+    JOB_SCHEDULE_UPDATED,
+    JOB_SCHEDULE_DELETED,
+    PROCESS_SCHEDULE_CREATED,
+    PROCESS_SCHEDULE_UPDATED,
+    PROCESS_SCHEDULE_DELETED
+}

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/service/NotificationService.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/service/NotificationService.java
@@ -1,0 +1,59 @@
+package com.halo.core_bridge.api.schedule.notification.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.core_bridge.api.schedule.notification.model.dto.NotificationPayload;
+import com.halo.core_bridge.api.schedule.notification.model.enums.NotificationType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ChannelTopic notificationTopic;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public void publishNotification(Long userId,
+                                    NotificationType type,
+                                    String message,
+                                    String jobTitle,
+                                    String link) {
+        try {
+            NotificationPayload payload = NotificationPayload.builder()
+                    .type(type)
+                    .title(resolveTitle(type))
+                    .message(message)
+                    .jobTitle(jobTitle)
+                    .link(link)
+                    .timestamp(Instant.now().toEpochMilli())
+                    .build();
+
+            String json = objectMapper.writeValueAsString(payload);
+            stringRedisTemplate.convertAndSend(notificationTopic.getTopic(), json);
+            log.info("📤 Redis Publish: topic={}, payload={}", notificationTopic.getTopic(), json);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to publish notification", e);
+        }
+    }
+
+    private String resolveTitle(NotificationType type) {
+        return switch (type) {
+            case JOB_SCHEDULE_CREATED -> "공고 일정 등록";
+            case JOB_SCHEDULE_UPDATED -> "공고 일정 수정";
+            case JOB_SCHEDULE_DELETED -> "공고 일정 삭제";
+            case PROCESS_SCHEDULE_CREATED -> "프로세스 일정 등록";
+            case PROCESS_SCHEDULE_UPDATED -> "프로세스 일정 수정";
+            case PROCESS_SCHEDULE_DELETED -> "프로세스 일정 삭제";
+            default -> "알림";
+        };
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/service/NotificationSseEmitterService.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/service/NotificationSseEmitterService.java
@@ -1,0 +1,47 @@
+package com.halo.core_bridge.api.schedule.notification.service;
+
+import com.halo.core_bridge.api.schedule.notification.model.dto.NotificationPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationSseEmitterService {
+    private static final Long DEFAULT_TIMEOUT = 60L * 60 * 1000; // 1h
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter subscribe(Long userId) {
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+        emitters.put(userId, emitter);
+        emitter.onCompletion(() -> emitters.remove(userId));
+        emitter.onTimeout(() -> emitters.remove(userId));
+        try {
+            emitter.send(SseEmitter.event().name("connected").data("connected"));
+        } catch (IOException ignored) {}
+        return emitter;
+    }
+
+    public void sendToUser(Long userId, NotificationPayload payload) {
+        SseEmitter emitter = emitters.get(userId);
+        if (emitter == null) { return; }
+        try {
+            emitter.send(SseEmitter.event().name("notification").data(payload));
+        } catch (IOException e) {
+            emitters.remove(userId);
+        }
+    }
+
+    public void broadcast(NotificationPayload payload) {
+        emitters.forEach((id, emitter) -> {
+            try { emitter.send(SseEmitter.event().name("notification").data(payload)); }
+            catch (IOException e) { emitters.remove(id); }
+        });
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/subscriber/RedisNotificationSubscriber.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/subscriber/RedisNotificationSubscriber.java
@@ -1,0 +1,36 @@
+package com.halo.core_bridge.api.schedule.notification.subscriber;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.core_bridge.api.schedule.notification.model.dto.NotificationPayload;
+import com.halo.core_bridge.api.schedule.notification.service.NotificationSseEmitterService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisNotificationSubscriber implements MessageListener {
+
+    private final NotificationSseEmitterService emitterService;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String json = new String(message.getBody());
+            log.info("📩 Redis Notification Received: {}", json);
+
+            NotificationPayload payload = mapper.readValue(json, NotificationPayload.class);
+
+            // 현재는 전체 broadcast (나중에 userId 매핑 로직 들어갈 예정)
+            emitterService.broadcast(payload);
+
+            log.info("✅ Notification broadcast 완료: {}", payload.getTitle());
+        } catch (Exception e) {
+            log.error("❌ Redis Notification 처리 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/schedule/process/service/ProcessScheduleService.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/process/service/ProcessScheduleService.java
@@ -2,6 +2,8 @@ package com.halo.core_bridge.api.schedule.process.service;
 
 import com.halo.core_bridge.api.jobposting.model.entity.JobPosting;
 import com.halo.core_bridge.api.jobposting.repository.JobPostingRepository;
+import com.halo.core_bridge.api.schedule.notification.model.enums.NotificationType;
+import com.halo.core_bridge.api.schedule.notification.service.NotificationService;
 import com.halo.core_bridge.api.schedule.process.model.dto.ProcessScheduleDto;
 import com.halo.core_bridge.api.schedule.process.model.entity.ProcessSchedule;
 import com.halo.core_bridge.api.schedule.process.repository.ProcessScheduleRepository;
@@ -23,6 +25,7 @@ import java.util.UUID;
 public class ProcessScheduleService {
     private final ProcessScheduleRepository processScheduleRepository;
     private final JobPostingRepository jobPostingRepository;
+    private final NotificationService notificationService;
 
     public List<ProcessScheduleDto.Response> getAll() {
         log.info("[ProcessScheduleService] getAll schedules");
@@ -60,6 +63,13 @@ public class ProcessScheduleService {
             }
         }
 
+        notificationService.publishNotification(
+                1L,
+                NotificationType.PROCESS_SCHEDULE_CREATED,
+                "채용 프로세스 단계가 생성되었습니다.",
+                jobPosting.getTitle(),
+                "/recruiter/jobs/" + jobPosting.getId() + "/schedule"
+        );
         return first.toDto();
     }
 
@@ -70,6 +80,13 @@ public class ProcessScheduleService {
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.PROCESS_SCHEDULE_NOT_FOUND));
         schedule.update(request);
 
+        notificationService.publishNotification(
+                1L,
+                NotificationType.PROCESS_SCHEDULE_UPDATED,
+                "프로세스 일정이 수정되었습니다: " + schedule.getTitle(),
+                schedule.getJobPosting().getTitle(),
+                "/recruiter/jobs/" + schedule.getJobPosting().getId() + "/schedule"
+        );
         return schedule.toDto();
     }
 
@@ -83,6 +100,14 @@ public class ProcessScheduleService {
         } else {
             processScheduleRepository.delete(schedule);
         }
+
+        notificationService.publishNotification(
+                1L,
+                NotificationType.PROCESS_SCHEDULE_DELETED,
+                "프로세스 일정이 삭제되었습니다: " + schedule.getTitle(),
+                schedule.getJobPosting().getTitle(),
+                "/recruiter/jobs/" + schedule.getJobPosting().getId() + "/schedule"
+        );
     }
 
     private JobPosting validateJobPostingExists(Long jobPostingId) {

--- a/src/main/java/com/halo/core_bridge/config/RedisConfig.java
+++ b/src/main/java/com/halo/core_bridge/config/RedisConfig.java
@@ -1,6 +1,8 @@
 package com.halo.core_bridge.config;
 
+import com.halo.core_bridge.api.schedule.notification.subscriber.RedisNotificationSubscriber;
 import com.halo.core_bridge.api.token.refresh.model.dto.RefreshTokenDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,11 +10,17 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@RequiredArgsConstructor
 public class RedisConfig {
+
+    private final RedisNotificationSubscriber redisNotificationSubscriber;
 
     @Value("${redis.host}")
     private String host;
@@ -45,5 +53,30 @@ public class RedisConfig {
 
         redisTemplate.afterPropertiesSet();
         return redisTemplate;
+    }
+
+    // notifications 채널
+    @Bean
+    public ChannelTopic notificationTopic() {
+        return new ChannelTopic("notifications");
+    }
+
+    // Redis 메시지 수신용 listenerAdapter
+    @Bean
+    public MessageListenerAdapter listenerAdapter() {
+        return new MessageListenerAdapter(redisNotificationSubscriber);
+    }
+
+    // Redis Pub/Sub 리스너 컨테이너 구성
+    @Bean
+    public RedisMessageListenerContainer redisContainer(
+            RedisConnectionFactory connectionFactory,
+            MessageListenerAdapter listenerAdapter,
+            ChannelTopic notificationTopic
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(listenerAdapter, notificationTopic);
+        return container;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closes #이슈번호, closes #이슈번호
> #24 closes
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

Redis와 SSE를 이용한 실시간 알림 기능 추가했습니다.

### 스크린샷 (선택)
<img width="1458" height="499" alt="image" src="https://github.com/user-attachments/assets/1d33acf6-a85a-4efb-b043-d6ec574f721f" />

<img width="1713" height="92" alt="image" src="https://github.com/user-attachments/assets/1c7a020c-05a3-42eb-90de-71e82cfe194c" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
