### PR TITLE
feat: 지원서 작성시 필요한 지원서 초기 데이터 중 지원자 정보 조회를 위한 기능

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/users/model/dto/UserDto.java
+++ b/src/main/java/com/halo/core_bridge/api/users/model/dto/UserDto.java
@@ -107,7 +107,7 @@ public class UserDto {
 
         private String name;
         private String email;
-        private Gender gender;
+        private String gender;
         private String phone;
         private LocalDate birth;
 
@@ -115,7 +115,7 @@ public class UserDto {
             return ResumeUserInfo.builder()
                     .name(entity.getName())
                     .email(entity.getEmail())
-                    .gender(entity.getGender())
+                    .gender(entity.getGender().getName())
                     .birth(entity.getBirth())
                     .phone(entity.getPhone())
                     .build();

--- a/src/main/java/com/halo/core_bridge/api/users/model/dto/UserDto.java
+++ b/src/main/java/com/halo/core_bridge/api/users/model/dto/UserDto.java
@@ -100,4 +100,25 @@ public class UserDto {
         private String email;
         private String password;
     }
+
+    @Getter
+    @Builder
+    public static class ResumeUserInfo  {
+
+        private String name;
+        private String email;
+        private Gender gender;
+        private String phone;
+        private LocalDate birth;
+
+        public static ResumeUserInfo from(User entity) {
+            return ResumeUserInfo.builder()
+                    .name(entity.getName())
+                    .email(entity.getEmail())
+                    .gender(entity.getGender())
+                    .birth(entity.getBirth())
+                    .phone(entity.getPhone())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/halo/core_bridge/api/users/service/UserService.java
+++ b/src/main/java/com/halo/core_bridge/api/users/service/UserService.java
@@ -47,4 +47,19 @@ public class UserService {
             throw BaseException.from(BaseResponseStatus.DUPLICATE_USER_EMAIL);
         }
     }
+
+    /**
+     * 이력서 작성 초기 데이터 구성에 필요한 지원자 정보를 조회 한다.
+     * @param userId 지원자의 식별자 ID
+     * @return UserDto.ResumeUserInfo 지원서 작성에 필요한 지원자 정보를 담은 DTO
+     * @throws BaseException - 회원이 존재하지 않는 경우 에외가 발생한다.
+     */
+    public UserDto.ResumeUserInfo findForResumeInfo(Long userId) {
+
+        User findUser = userRepository.findById(userId).orElseThrow(
+                () -> BaseException.from(BaseResponseStatus.NOT_FOUND_USER)
+        );
+
+        return UserDto.ResumeUserInfo.from(findUser);
+    }
 }

--- a/src/test/java/com/halo/core_bridge/api/users/service/UserServiceTest.java
+++ b/src/test/java/com/halo/core_bridge/api/users/service/UserServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 
 import java.sql.SQLException;
 import java.time.LocalDate;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -130,5 +131,37 @@ class UserServiceTest {
         // when
         // then
         assertDoesNotThrow(() -> userService.existByEmail("test@test.com"));
+    }
+
+    @Test
+    @DisplayName("지원서 작성 시 필요한 지원자 정보 조회 성공")
+    void findResumeUserInfoSuccess() {
+
+        // given
+        User willReturnUser = User.builder()
+                .id(1L)
+                .email("test01@test.com")
+                .birth(LocalDate.of(1996, 12, 16))
+                .password("12345678")
+                .phone("010-1234-5678")
+                .gender(Gender.Male)
+                .name("test")
+                .userRole(
+                        UserRole.builder().id(1).build()
+                )
+                .build();
+
+        given(userRepository.findById(any(Long.class))).willReturn(Optional.ofNullable(willReturnUser));
+
+        // when
+        UserDto.ResumeUserInfo findResumeUserInfo = userService.findForResumeInfo(willReturnUser.getId());
+
+        // then
+        assertThat(findResumeUserInfo).isNotNull();
+        assertThat(findResumeUserInfo.getName()).isEqualTo(willReturnUser.getName());
+        assertThat(findResumeUserInfo.getEmail()).isEqualTo(willReturnUser.getEmail());
+        assertThat(findResumeUserInfo.getBirth()).isEqualTo(willReturnUser.getBirth());
+        assertThat(findResumeUserInfo.getGender()).isEqualTo(willReturnUser.getGender().getName());
+        assertThat(findResumeUserInfo.getPhone()).isEqualTo(willReturnUser.getPhone());
     }
 }

--- a/src/test/java/com/halo/core_bridge/api/users/service/UserServiceTest.java
+++ b/src/test/java/com/halo/core_bridge/api/users/service/UserServiceTest.java
@@ -164,4 +164,29 @@ class UserServiceTest {
         assertThat(findResumeUserInfo.getGender()).isEqualTo(willReturnUser.getGender().getName());
         assertThat(findResumeUserInfo.getPhone()).isEqualTo(willReturnUser.getPhone());
     }
+
+    @Test
+    @DisplayName("지원서 작성 시 필요한 지원자 정보 조회 중 존재하지 않는 사용자일 때 예외 발생")
+    void findResumeUserInfoFailed() {
+
+        // given
+        User willReturnUser = User.builder()
+                .id(1L)
+                .email("test01@test.com")
+                .birth(LocalDate.of(1996, 12, 16))
+                .password("12345678")
+                .phone("010-1234-5678")
+                .gender(Gender.Male)
+                .name("test")
+                .userRole(
+                        UserRole.builder().id(1).build()
+                )
+                .build();
+
+        given(userRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThrows(BaseException.class, () -> userService.findForResumeInfo(willReturnUser.getId()));
+    }
 }


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #85 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 지원서 작성 시 필요한 지원서 초기 데이터 중 지원자 정보를 조회하는 기능을 구현하였습니다.
* Gender 직렬화를 어노테이션을 사용하여 처리할 수 있었지만, Gender를 응답으로 내려주는 DTO들의 구조가 모두 달라 DTO로 변환시 수동으로 변환하도록 하였습니다.

## 스크린샷 (선택)

* UserService

<img width="2720" height="1512" alt="image" src="https://github.com/user-attachments/assets/ddbe3982-ef84-46a8-8b25-fdc41aa10b78" />


* DTO


<img width="2012" height="2160" alt="image" src="https://github.com/user-attachments/assets/f43cf2d0-d1d2-4cd3-b7f6-b2c6310f5948" />


* Test Code


<img width="3876" height="6048" alt="image" src="https://github.com/user-attachments/assets/f088c06a-cc9f-4b47-ba9c-5328e5ea565f" />


# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항

