### PR TITLE
feat: 채용 프로세스 정렬 순서 변경 기능

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/jobposting/controller/RecruitProcessController.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/controller/RecruitProcessController.java
@@ -7,6 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/recruiter/processes")
@@ -28,5 +31,14 @@ public class RecruitProcessController {
 
         RecruitProcessDto.recruitProcesses findRecruitProcesses = recruitProcessService.findAllRecruitProcessesByJobPostingId(jobPostingId);
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(findRecruitProcesses));
+    }
+
+    @PatchMapping
+    public ResponseEntity<BaseResponse<Object>> changeProcessOrder(RecruitProcessDto.ChangeOrder changeOrder) {
+
+        recruitProcessService.changeOrder(changeOrder);
+        RecruitProcessDto.recruitProcesses recruitProcesses = recruitProcessService.findAllRecruitProcessesByJobPostingId(changeOrder.getJobPostingId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(recruitProcesses));
     }
 }

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/RecruitProcessDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/RecruitProcessDto.java
@@ -66,4 +66,12 @@ public class RecruitProcessDto {
 
         }
     }
+
+    @Getter
+    public static class ChangeOrder {
+        private Long processId;
+        private Long jobPostingId;
+        private int fromIdx;
+        private int toIdx;
+    }
 }

--- a/src/main/java/com/halo/core_bridge/api/jobposting/repository/RecruitProcessRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/repository/RecruitProcessRepository.java
@@ -3,6 +3,9 @@ package com.halo.core_bridge.api.jobposting.repository;
 import com.halo.core_bridge.api.jobposting.model.entity.JobPosting;
 import com.halo.core_bridge.api.jobposting.model.entity.RecruitProcess;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,4 +17,50 @@ public interface RecruitProcessRepository extends JpaRepository<RecruitProcess, 
 
     void deleteAllByJobPosting(JobPosting jobPosting);
 
+    /**
+     * <code>JobPostingId</code>의 채용 프로세스들 중에서 <br>
+     * <code>orderIdx</code>가 </code><code>fromIdx</code>부터 <code>toIdx</code> 범위의 <code>orderIdx</code>값들을 1씩 증가 시킨다.
+     * @param jobPostingId 채용프로세스 목록을 찾기위한 채용 공고 ID
+     * @param fromIdx 기존 정렬 순서 Idx
+     * @param toIdx 변경할 정렬 순서 Idx
+     */
+    @Modifying
+    @Query("""
+            update RecruitProcess rp
+            set rp.orderIdx = rp.orderIdx + 1
+            where rp.jobPosting.id = :jobPostingId
+            and rp.orderIdx
+            between :toIdx and :fromIdx - 1
+    """)
+    void incrementOrderIdxes(@Param("jobPostingId") Long jobPostingId, @Param("fromIdx") int fromIdx, @Param("toIdx") int toIdx);
+
+    /**
+     * <code>JobPostingId</code>의 채용 프로세스들 중에서 <br>
+     * <code>orderIdx</code>가 </code><code>fromIdx</code>부터 <code>toIdx</code> 범위의 <code>orderIdx</code>값들을 1씩 감소 시킨다.
+     * @param jobPostingId 채용프로세스 목록을 찾기위한 채용 공고 ID
+     * @param fromIdx 기존 정렬 순서 Idx
+     * @param toIdx 변경할 정렬 순서 Idx
+     */
+    @Modifying
+    @Query("""
+            update RecruitProcess rp
+            set rp.orderIdx = rp.orderIdx + -1
+            where rp.jobPosting.id = :jobPostingId
+            and rp.orderIdx
+            between :fromIdx + 1 and :toIdx
+    """)
+    void decrementOrderIdxes(@Param("jobPostingId") Long jobPostingId, @Param("fromIdx") int fromIdx, @Param("toIdx") int toIdx);
+
+    /**
+     * 채용 프로세스의 정렬 순서인 <code>orderIdx</code>를 <code>toIdx</code>로 변경한다.
+     * @param processId 정렬순서 <code>orderIdx</code>를 수정할 채용 프로세스 Id
+     * @param toIdx 변경할 정렬 순서
+     */
+    @Modifying
+    @Query("""
+            update RecruitProcess rp
+            set rp.orderIdx = :toIdx
+            where rp.id = :processId
+    """)
+    void updateOrderIdx(@Param("processId") Long processId, @Param("toIdx") int toIdx);
 }

--- a/src/main/java/com/halo/core_bridge/api/jobposting/service/RecruitProcessService.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/service/RecruitProcessService.java
@@ -29,4 +29,29 @@ public class RecruitProcessService {
         List<RecruitProcess> findAllByJobPosting = recruitProcessRepository.findByJobPosting_IdOrderByOrderIdxAsc(jobPostingId);
         return RecruitProcessDto.recruitProcesses.from(findAllByJobPosting);
     }
+
+    /**
+     * 채용 프로세스의 순서를 변경한다. <br>
+     * <code>fromIdx</code>가 <code>toIdx</code> 값보다 작으면 채용 프로세스는 뒤로 이동한다. <br>
+     * 이때, <code>fromIdx</code>와 <code>toIdx</code> 사이의 OrderIndex들은 1씩 감소한다. <br>
+     * <br>
+     * <code>fromIdx</code>가 <code>toIdx</code> 값보다 크면 채용 프로세스는 앞으로 이동한다. <br>
+     * 이때, <code>fromIdx</code>와 <code>toIdx</code> 사이의 OrderIndex들은 1씩 증가한다.
+     * @param changeOrder 순서를 변경하는데 필요한 DTO
+     */
+    @Transactional
+    public void changeOrder(RecruitProcessDto.ChangeOrder changeOrder) {
+        adjustOrderIndexes(changeOrder.getFromIdx(), changeOrder.getToIdx(), changeOrder.getJobPostingId());
+        recruitProcessRepository.updateOrderIdx(changeOrder.getProcessId(), changeOrder.getToIdx());
+    }
+
+    private void adjustOrderIndexes(int fromIdx, int toIdx, Long joPostingId) {
+
+        // 프로세스가 뒤로 이동, 사이에 있는 인덱스들은 1씩 감소
+        if (toIdx < fromIdx) {
+            recruitProcessRepository.decrementOrderIdxes(joPostingId, fromIdx, toIdx);
+        } else if (toIdx > fromIdx) {
+            recruitProcessRepository.incrementOrderIdxes(joPostingId, fromIdx, toIdx);
+        }
+    }
 }


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #95 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

채용 프로세스 순서를 변경하는 기능을 구현하였습니다. 
채용 프로세스의 순서가 뒤로 이동하는 경우 그 앞의 채용 프로세스들은 정렬 순서를 1씩 감소되도록 구현하였습니다.
채용 프로세스의 순서가 앞으로 이동하는 경우 그 앞의 채용 프로세스들은 정렬 순서를 1씩 증가 시키도록 구현하였습니다.

## 스크린샷 (선택)

<img width="5660" height="864" alt="image" src="https://github.com/user-attachments/assets/d2c610ac-762a-4860-9807-c7ece3e72f12" />


<img width="1252" height="756" alt="image" src="https://github.com/user-attachments/assets/0a9f6309-1103-4049-9b93-b4434b50fffe" />


<img width="4104" height="2456" alt="image" src="https://github.com/user-attachments/assets/6a877484-8a62-4af3-8cf3-aae8d0b225d0" />


<img width="4900" height="4736" alt="image" src="https://github.com/user-attachments/assets/900bd782-f179-40aa-98a2-4883f26307bb" />


# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항

`@Modifying`은 `@Qeury`를 사용한 `UPDATE` JPQL을 작성하기 위하여 사용 하였습니다.
