### PR TITLE
fix: RecruitProcessController.changeProcessOrder의 파라미터 수정

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/jobposting/controller/RecruitProcessController.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/controller/RecruitProcessController.java
@@ -34,7 +34,7 @@ public class RecruitProcessController {
     }
 
     @PatchMapping
-    public ResponseEntity<BaseResponse<Object>> changeProcessOrder(RecruitProcessDto.ChangeOrder changeOrder) {
+    public ResponseEntity<BaseResponse<Object>> changeProcessOrder(@RequestBody RecruitProcessDto.ChangeOrder changeOrder) {
 
         recruitProcessService.changeOrder(changeOrder);
         RecruitProcessDto.recruitProcesses recruitProcesses = recruitProcessService.findAllRecruitProcessesByJobPostingId(changeOrder.getJobPostingId());


### PR DESCRIPTION
@RequestBody를 파라미터에 추가

# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #99 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 채용 프로세스 목록 조회 요청 시 `body` 데이터를 받지 못하는 버그를 해결하였습니다.
* `@RequestBody`를 붙여 `body`에 담긴 데이터를 파싱하도록 수정하였습니다.

## 스크린샷 (선택)

<img width="5660" height="864" alt="image" src="https://github.com/user-attachments/assets/55fba815-4e81-4f72-b355-3db000c188ee" />



# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
