### PR TITLE
fix: 채용 프로세스 순서 변경 시 다른 채용 프로세스 orderIdx가 변경되지 않는 버그 해결

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/jobposting/service/RecruitProcessService.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/service/RecruitProcessService.java
@@ -48,9 +48,9 @@ public class RecruitProcessService {
     private void adjustOrderIndexes(int fromIdx, int toIdx, Long joPostingId) {
 
         // 프로세스가 뒤로 이동, 사이에 있는 인덱스들은 1씩 감소
-        if (toIdx < fromIdx) {
+        if (toIdx > fromIdx) {
             recruitProcessRepository.decrementOrderIdxes(joPostingId, fromIdx, toIdx);
-        } else if (toIdx > fromIdx) {
+        } else if (toIdx < fromIdx) {
             recruitProcessRepository.incrementOrderIdxes(joPostingId, fromIdx, toIdx);
         }
     }


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #101 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 채용 프로세스 순서 변경 시 나머지 프로세스의 `orderIdx`가 변경되지 않는 버그를 수정하였습니다.

## 스크린샷 (선택)

*  `toIdx`와 `fromIdx`의 조건에 맞는 호출을 반대로 수행하고 있어 해당 버그가 발생하였습니다. 아래는 조건에 맞게 올바른 메서드 호출로 변경한 코드입니다.

<img width="3116" height="972" alt="image" src="https://github.com/user-attachments/assets/50d78869-af3b-4eb1-8f75-3c632294c335" />

* 아래는 버그 해결 수 정상 동작하는 프론트 화면입니다. 순서가 변경될 때마다 왼쪽의 인덱스 번호가 올바르게 바뀌는 것을 확인 할 수 있습니다.

![process-dnd-with-back](https://github.com/user-attachments/assets/12d7e64b-f27a-4be2-beb4-1b87081efd2f)


# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
