### PR TITLE
fix: 새 프로세스 추가 시 발생하는 버그 해결

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/jobposting/controller/RecruitProcessController.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/controller/RecruitProcessController.java
@@ -1,15 +1,13 @@
 package com.halo.core_bridge.api.jobposting.controller;
 
-import com.halo.core_bridge.api.jobposting.model.dto.RecruitProcessDto;
 import com.halo.core_bridge.api.jobposting.service.RecruitProcessService;
 import com.halo.core_bridge.common.model.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+
+import static com.halo.core_bridge.api.jobposting.model.dto.RecruitProcessDto.*;
 
 @RestController
 @RequestMapping("/api/recruiter/processes")
@@ -19,25 +17,28 @@ public class RecruitProcessController {
     private final RecruitProcessService recruitProcessService;
 
     @PostMapping
-    public ResponseEntity<BaseResponse<Object>> createRecruitProcess(@RequestBody RecruitProcessDto.Create createRecruitProcessDto) {
+    public ResponseEntity<BaseResponse<recruitProcesses>> createRecruitProcess(@RequestBody Create createRecruitProcess) {
 
-        recruitProcessService.add(createRecruitProcessDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.success("채용 프로세스 추가 완료"));
+        recruitProcessService.add(createRecruitProcess);
 
+        recruitProcesses recruitProcesses =
+                recruitProcessService.findAllRecruitProcessesByJobPostingId(createRecruitProcess.getJobPostingId());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.success(recruitProcesses));
     }
 
     @GetMapping
-    public ResponseEntity<BaseResponse<RecruitProcessDto.recruitProcesses>> getRecruitProcesses(@RequestParam("recruit") Long jobPostingId) {
+    public ResponseEntity<BaseResponse<recruitProcesses>> getRecruitProcesses(@RequestParam("recruit") Long jobPostingId) {
 
-        RecruitProcessDto.recruitProcesses findRecruitProcesses = recruitProcessService.findAllRecruitProcessesByJobPostingId(jobPostingId);
+        recruitProcesses findRecruitProcesses = recruitProcessService.findAllRecruitProcessesByJobPostingId(jobPostingId);
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(findRecruitProcesses));
     }
 
     @PatchMapping
-    public ResponseEntity<BaseResponse<Object>> changeProcessOrder(@RequestBody RecruitProcessDto.ChangeOrder changeOrder) {
+    public ResponseEntity<BaseResponse<Object>> changeProcessOrder(@RequestBody ChangeOrder changeOrder) {
 
         recruitProcessService.changeOrder(changeOrder);
-        RecruitProcessDto.recruitProcesses recruitProcesses = recruitProcessService.findAllRecruitProcessesByJobPostingId(changeOrder.getJobPostingId());
+        recruitProcesses recruitProcesses = recruitProcessService.findAllRecruitProcessesByJobPostingId(changeOrder.getJobPostingId());
 
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(recruitProcesses));
     }

--- a/src/main/java/com/halo/core_bridge/api/jobposting/controller/RecruitProcessController.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/controller/RecruitProcessController.java
@@ -19,7 +19,7 @@ public class RecruitProcessController {
     private final RecruitProcessService recruitProcessService;
 
     @PostMapping
-    public ResponseEntity<BaseResponse<Object>> createRecruitProcess(RecruitProcessDto.Create createRecruitProcessDto) {
+    public ResponseEntity<BaseResponse<Object>> createRecruitProcess(@RequestBody RecruitProcessDto.Create createRecruitProcessDto) {
 
         recruitProcessService.add(createRecruitProcessDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.success("채용 프로세스 추가 완료"));

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/RecruitProcessDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/RecruitProcessDto.java
@@ -23,11 +23,12 @@ public class RecruitProcessDto {
         @NotBlank(message = "채용 공고 ID는 필수 입력 값 입니다.")
         private Long jobPostingId;
 
-        public RecruitProcess toEntity() {
+        public RecruitProcess toEntity(int orderIdx) {
 
             return RecruitProcess.builder()
                     .name(this.name)
                     .colorCode(this.colorCode)
+                    .orderIdx(orderIdx)
                     .jobPosting(
                             JobPosting.builder().id(jobPostingId).build()
                     )

--- a/src/main/java/com/halo/core_bridge/api/jobposting/repository/RecruitProcessRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/repository/RecruitProcessRepository.java
@@ -63,4 +63,21 @@ public interface RecruitProcessRepository extends JpaRepository<RecruitProcess, 
             where rp.id = :processId
     """)
     void updateOrderIdx(@Param("processId") Long processId, @Param("toIdx") int toIdx);
+
+    /**
+     * 특정 채용 공고의 채용 프로세스 중에서 orderIdx의 최대값을 조회한다.
+     * @param jobPostingId 채용 공고 <code>id</code>
+     * @return <code>Integer</code> - <code>orderIdx의</code> 최대값을 반환한다. 없다면 <code>null</code>을 반환한다.
+     */
+    @Query("select max(r.orderIdx) from RecruitProcess r where r.jobPosting.id = :jobPostingId")
+    Integer findMaxOrderByJobPostingId(@Param("jobPostingId") Long jobPostingId);
+
+    /**
+     * 마지막 채용 프로세스의 <code>orderIdx</code>를 1 증가 시킨다.
+     * @param jobPostingId 채용 공고 <code>id</code>
+     * @param lastOrderIdx 마지막 프로세스의 <code>orderIdx</code>
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update RecruitProcess r set r.orderIdx = r.orderIdx + 1 where r.jobPosting.id = :jobPostingId and r.orderIdx = :lastOrderIdx")
+    void shiftLastOrderIdx(@Param("jobPostingId") Long jobPostingId, @Param("lastOrderIdx") Integer lastOrderIdx);
 }

--- a/src/main/java/com/halo/core_bridge/api/jobposting/service/RecruitProcessService.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/service/RecruitProcessService.java
@@ -15,11 +15,27 @@ public class RecruitProcessService {
 
     private final RecruitProcessRepository recruitProcessRepository;
 
+    /**
+     * 새로운 채용 프로세스를 저장한다.
+     * @param createRecruitProcess 저장할 채용 프로세스
+     * @return <code>Long</code> 새로 저장된 채용 프로세스의 식별자 <code>id</code>를 반환
+     */
     @Transactional
     public Long add(RecruitProcessDto.Create createRecruitProcess) {
 
-        RecruitProcess recruitProcessEntity = createRecruitProcess.toEntity();
-        RecruitProcess savedRecruitProcess = recruitProcessRepository.save(recruitProcessEntity);
+        // 제일 큰 정렬 번호를 가져온다.
+        Integer lastOrderIdx = recruitProcessRepository.findMaxOrderByJobPostingId(createRecruitProcess.getJobPostingId());
+
+        if (lastOrderIdx == null) {
+            RecruitProcess savedRecruitProcess = recruitProcessRepository.save(createRecruitProcess.toEntity(1));
+            return savedRecruitProcess.getId();
+        }
+
+        // 마지막 프로세스의 정렬 번호를 1 증가
+        recruitProcessRepository.shiftLastOrderIdx(createRecruitProcess.getJobPostingId(), lastOrderIdx);
+
+        // 새로 추가된 프로세스에 이전의 마지막 프로세스 정렬 번호를 입력
+        RecruitProcess savedRecruitProcess = recruitProcessRepository.save(createRecruitProcess.toEntity(lastOrderIdx));
 
         return savedRecruitProcess.getId();
     }


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #104 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 새 프로세스 추가 시 발생하는 버그를 해결하였습니다.
* orderIdx가 지정되지 않아 저장 시 예외가 발생하였습니다.
* service 계층의 save()에서 orderIdx를 설정해주었고, 채용 프로세스가 하나라도 있는 경우와 하나라도 없는 경우를 분기 조건으로 처리하였습니다.


* 채용 프로세스가 존재하는 채용 공고라면 다음과 같이 로직을 수행하였습니다.

1. 현재 채용 공고의 채용 프로세스 중 제일 정렬 번호가 큰 값을 구합니다.
2. 해당 정렬 번호를 가지고 있는 채용 프로세스를 찾아 정렬 번호를 1 증가시킵니다.
3. 새로운 프로세스의 정렬 번호를 1번에서 찾은 정렬 번호로 지정합니다.
4. 새롭게 정렬번호가 지정된 새 프로세스를 저장합니다.

## 스크린샷 (선택)

<img width="5244" height="1612" alt="image" src="https://github.com/user-attachments/assets/ccc7872a-ed83-490b-9314-5ee9b0ac6df4" />


<img width="4672" height="2548" alt="image" src="https://github.com/user-attachments/assets/48557b1e-9d1e-4698-b1bf-f25e32d0b304" />


<img width="4484" height="1080" alt="image" src="https://github.com/user-attachments/assets/8a52c7c8-9e19-4e11-aadf-e630ce610138" />


# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
