### PR TITLE
refactor: 채용 프로세스 조회 응답 데이터 구조 수정

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/jobposting/controller/RecruitProcessController.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/controller/RecruitProcessController.java
@@ -47,7 +47,7 @@ public class RecruitProcessController {
     public ResponseEntity<BaseResponse<Object>> updateProcessName(@PathVariable Long processId ,@RequestBody update updateRecruitProcess) {
 
         recruitProcessService.editRecruitProcess(processId, updateRecruitProcess);
-        recruitProcesses recruitProcesses = recruitProcessService.findAllRecruitProcessesByJobPostingId(processId);
+        recruitProcesses recruitProcesses = recruitProcessService.findAllRecruitProcessesByJobPostingId(updateRecruitProcess.getJobPostingId());
 
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(recruitProcesses));
     }

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/RecruitProcessDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/RecruitProcessDto.java
@@ -42,14 +42,14 @@ public class RecruitProcessDto {
 
         private Long id;
         private String name;
-        private String colorCode;
+        private ColorCode colorCode;
         private int orderIdx;
 
         public static RecruitProcessDto.Read from(RecruitProcess entity) {
             return Read.builder()
                     .id(entity.getId())
                     .name(entity.getName())
-                    .colorCode(entity.getColorCode().getColorCode())
+                    .colorCode(entity.getColorCode())
                     .orderIdx(entity.getOrderIdx())
                     .build();
         }

--- a/src/main/java/com/halo/core_bridge/common/model/ColorCode.java
+++ b/src/main/java/com/halo/core_bridge/common/model/ColorCode.java
@@ -1,10 +1,11 @@
 package com.halo.core_bridge.common.model;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.halo.core_bridge.common.serialize.ColorCodeSerializer;
 import lombok.Getter;
 
 @Getter
-@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@JsonSerialize(using = ColorCodeSerializer.class)
 public enum ColorCode {
 
     BLUE("파랑", "blue-500"),
@@ -13,11 +14,11 @@ public enum ColorCode {
     PURPLE("보라", "purple-500"),
     PINK("분홍", "pink-500");
 
-    private final String name;
+    private final String label;
     private final String code;
 
-    ColorCode(String name, String code) {
-        this.name = name;
+    ColorCode(String label, String code) {
+        this.label = label;
         this.code = code;
     }
 }

--- a/src/main/java/com/halo/core_bridge/common/model/ColorCode.java
+++ b/src/main/java/com/halo/core_bridge/common/model/ColorCode.java
@@ -1,8 +1,10 @@
 package com.halo.core_bridge.common.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 
 @Getter
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ColorCode {
 
     BLUE("파랑", "blue-500"),
@@ -11,11 +13,11 @@ public enum ColorCode {
     PURPLE("보라", "purple-500"),
     PINK("분홍", "pink-500");
 
-    private final String colorName;
-    private final String colorCode;
+    private final String name;
+    private final String code;
 
-    ColorCode(String colorName, String colorCode) {
-        this.colorName = colorName;
-        this.colorCode = colorCode;
+    ColorCode(String name, String code) {
+        this.name = name;
+        this.code = code;
     }
 }

--- a/src/main/java/com/halo/core_bridge/common/serialize/ColorCodeSerializer.java
+++ b/src/main/java/com/halo/core_bridge/common/serialize/ColorCodeSerializer.java
@@ -1,0 +1,21 @@
+package com.halo.core_bridge.common.serialize;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.halo.core_bridge.common.model.ColorCode;
+
+import java.io.IOException;
+
+public class ColorCodeSerializer extends JsonSerializer<ColorCode> {
+
+    @Override
+    public void serialize(ColorCode value, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException {
+        gen.writeStartObject();
+        gen.writeStringField("name", value.name());
+        gen.writeStringField("label", value.getLabel());
+        gen.writeStringField("code", value.getCode());
+        gen.writeEndObject();
+    }
+}


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #108 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 채용 프로세스 조회를 담는 응답 DTO의 데이터 구조를 변경하였습니다.
* ColorCode의 필드 명을 변경하였습니다.
* ColorCode의 JSON 포맷을 지정하였습니다.

```
{
  ...
  colorCode: 'purple-500'
  ...
}
```
위의 구조에서 다음 아래의 구조로 변경하였습니다.

```
{
  ...
  colorCode: {
    name: '파랑',
    code: 'blue-500'
  ...
  }
}
```



## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
