### PR TITLE
feat: 채용공고 상세조회에 따른 응답 dto 분리

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/jobposting/contents/SwaggerJobPostingContents.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/contents/SwaggerJobPostingContents.java
@@ -94,47 +94,99 @@ public class SwaggerJobPostingContents {
     // ✅ 채용공고 단건 상세 조회 응답
     public static final String JOB_POSTING_DETAIL_RESPONSE = """
             {
-                 "success": true,
-                 "code": 20000,
-                 "message": "요청에 성공하였습니다.",
-                 "results": {
-                     "id": 1,
-                     "title": "시니어 프론트엔드 개발자",
-                     "employmentType": "정규직",
-                     "careerType": "신입",
-                     "minExperience": 5,
-                     "maxExperience": 10,
-                     "positionLevel": "시니어",
-                     "location": "서울 성수",
-                     "applyStartDate": "2025-10-10 09:00:00",
-                     "applyEndDate": "2025-10-29 18:00:00",
-                     "hireEndDate": "2025-10-31 18:00:00",
-                     "headcount": 3,
-                     "summary": "고객용 대시보드 및 관리자 콘솔의 프론트엔드 개발을 리드합니다.",
-                     "responsibilities": "Vue 3 + TypeScript 기반 신규 기능 개발, UI 아키텍처 설계, 성능 최적화, 코드 리뷰.",
-                     "requirements": "Vue 3, TypeScript 실무 5년 이상 경험. 상태관리(Pinia, Vuex) 및 REST API 연동 경험.",
-                     "preferred": "대규모 트래픽 대응 경험, SSR(Nuxt) 경험, 디자인 시스템 구축 경험.",
-                     "techStack": [],
-                     "recruitProcess": [
-                         "지원 완료",
-                         "서류 검토",
-                         "1차 면접",
-                         "최종 합격"
-                     ],
-                     "salaryType": "연봉",
-                     "salaryMin": 6500,
-                     "salaryMax": 8500,
-                     "salaryNegotiable": true,
-                     "workingHours": "09:00 ~ 18:00 (주 5일)",
-                     "benefits": "중식 제공, 자율 출퇴근, 재택근무 가능, 교육비 지원",
-                     "additionalInfo": "포트폴리오 또는 GitHub 링크를 함께 제출해주세요.",
-                     "departmentId": 1,
-                     "departmentName": "플랫폼개발팀",
-                     "contactName": "김채용",
-                     "contactEmail": "recruit@example.com",
-                     "createdUserId": 1
-                 }
-             }
+                  "success": true,
+                  "code": 20000,
+                  "message": "요청에 성공하였습니다.",
+                  "results": {
+                      "id": 3,
+                      "summary": "CoreBridge SaaS 플랫폼 디자인 전반 담당",
+                      "responsibilities": "UI/UX 설계 및 서비스 리디자인 프로젝트 수행",
+                      "requirements": "Figma, Photoshop, Illustrator 숙련자",
+                      "preferred": "프로덕트 디자인, 브랜드 디자인 모두 가능한 멀티형 디자이너\\n  ㅁㄴㅇ;럼;ㅣㅏ넝히ㅏ;먼이;ㅏㅓ라ㅣ;ㅁ넝;ㅏㅣㅓㅁㄴ;ㅣ어리ㅏ;ㅁ너아ㅣㄹ@:\\n  ㅁ니ㅏㅇ;러;미넝ㅎ;ㅏㅣ먼아ㅣ허\\n  ㅁㄴ아ㅣ험;ㅣ나ㅓ하ㅣㅁ넝ㅎ\\n  ㅁ날허;미ㅏㄴ렇;ㅏㅣ머라ㅣㅎ",
+                      "benefits": "점심 지원, 유연근무, 도서구입비 지원",
+                      "additionalInfo": "포트폴리오 필수, Figma 협업 경험 우대",
+                      "status": "마감",
+                      "createDate": "2025-10-27 07:41:04",
+                      "applyStartDate": "2025-10-10 09:00:00",
+                      "applyEndDate": "2025-10-10 18:00:00",
+                      "hireEndDate": "2025-10-26 18:00:00",
+                      "headCount": 4,
+                      "applicantCount": null,
+                      "skills": [
+                          "Figma",
+                          "Illustrator",
+                          "Photoshop",
+                          "Zeplin"
+                      ],
+                      "recruitProcesses": [
+                          {
+                              "id": 11,
+                              "name": "지원 완료",
+                              "colorCode": "blue-500",
+                              "orderIdx": 1
+                          },
+                          {
+                              "id": 12,
+                              "name": "서류 검토",
+                              "colorCode": "orange-500",
+                              "orderIdx": 2
+                          },
+                          {
+                              "id": 13,
+                              "name": "1차 면접",
+                              "colorCode": "purple-500",
+                              "orderIdx": 3
+                          },
+                          {
+                              "id": 14,
+                              "name": "2차 면접",
+                              "colorCode": "red-500",
+                              "orderIdx": 4
+                          },
+                          {
+                              "id": 15,
+                              "name": "최종 합격",
+                              "colorCode": "pink-500",
+                              "orderIdx": 5
+                          }
+                      ],
+                      "workingHours": "10:00 ~ 19:00 (주 5일)",
+                      "location": "서울 강남",
+                      "contactName": "이디자인",
+                      "contactEmail": "design@halo.com"
+                  }
+              }
+            """;
+
+    public static final String JOB_POSTING_BASIC_RESPONSE = """
+            {
+                    "success": true,
+                    "code": 20000,
+                    "message": "요청에 성공하였습니다.",
+                    "results": {
+                        "id": 1,
+                        "title": "시니어 프론트엔드 개발자",
+                        "status": "채용중",
+                        "departmentName": "플랫폼개발팀",
+                        "employmentType": "정규직",
+                        "location": "서울 성수",
+                        "careerType": "신입",
+                        "minExperience": 5,
+                        "maxExperience": 10,
+                        "skills": [
+                            "JAVA",
+                            "Vue",
+                            "TypeScript",
+                            "Pinia",
+                            "Vite",
+                            "TailwindCSS"
+                        ],
+                        "salaryType": "연봉",
+                        "salaryMin": 6500,
+                        "salaryMax": 8500,
+                        "salaryNegotiable": true
+                    }
+                }
             """;
 
     // ✅ 채용공고 상세조회 시 존재하지 않을 때

--- a/src/main/java/com/halo/core_bridge/api/jobposting/controller/JobPostingController.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/controller/JobPostingController.java
@@ -139,6 +139,36 @@ public class JobPostingController {
         return ResponseEntity.ok(BaseResponse.success(detail)); // HTTP 200 OK
     }
 
+    @Operation(
+            summary = "채용공고 기본정보 조회",
+            description = "특정 ID의 채용공고의 기본정보를 조회합니다. Header부분"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "Detail Response Example",
+                                    value = SwaggerJobPostingContents.JOB_POSTING_BASIC_RESPONSE
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 채용공고",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "Not Found Response",
+                                    value = SwaggerJobPostingContents.JOB_POSTING_NOT_FOUND_RESPONSE
+                            )
+                    )
+            )
+    })
+    @GetMapping("/header/{id}")
+    public ResponseEntity<BaseResponse<JobPostingDto.HeaderResponse>>  getJobPostingHeader(@PathVariable Long id) {
+        JobPostingDto.HeaderResponse headerDetail = jobPostingService.getHeaderDetail(id);
+        return ResponseEntity.ok(BaseResponse.success(headerDetail));
+    }
+
 
     //채용공고 수정
     @PatchMapping("/{id}")

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
@@ -4,15 +4,14 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.halo.core_bridge.api.jobposting.model.entity.*;
 import com.halo.core_bridge.api.organization.model.entity.Department;
 import com.halo.core_bridge.api.users.model.entity.User;
+import com.halo.core_bridge.common.model.ColorCode;
 import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 
 
 public class JobPostingDto {
@@ -290,116 +289,124 @@ public class JobPostingDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class DetailResponse {
-        // 식별자
+    public static class HeaderResponse {
         private Long id;
-
-        // 기본 정보
+        //기본 정보
         private String title;
+        private String status;
+        private String departmentName;
         private EmploymentType employmentType;
+        private String location;
         private CareerType careerType;
         private Integer minExperience;
         private Integer maxExperience;
-        private String positionLevel;
-        private String location;
-
-        // 기간(저장값 그대로)
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-        private LocalDateTime applyStartDate;
-
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-        private LocalDateTime applyEndDate;
-
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-        private LocalDateTime hireEndDate;
-
-        // 모집 및 지원자 수
-        private Integer headcount;
-        private Integer applicantCount;
-
-        // 직무 상세(저장값 그대로)
-        private String summary;
-        private String responsibilities;
-        private String requirements;
-        private String preferred;
-
-        // 기술/프로세스 (저장값의 이름 리스트)
-        private List<String> techStack;        // JobPostingSkill.name 리스트
-        private List<String> recruitProcess;    // RecruitProcess.name 리스트 (orderIndex 오름차순)
-
-        // 급여
+        private List<String> skills;
         private SalaryType salaryType;
         private Integer salaryMin;
         private Integer salaryMax;
-        private Boolean salaryNegotiable;
+        private Boolean SalaryNegotiable;
 
-        // 근무 조건/복리후생/기타
-        private String workingHours;
-        private String benefits;
-        private String additionalInfo;
-
-        // 부서/담당/등록자
-        private Long departmentId;
-        private String departmentName;          // 편의용(엔티티 그대로)
-        private String contactName;
-        private String contactEmail;
-        private Long createdUserId;
-
-        // -----------------------------
-        // 정적 팩토리 - 엔티티 그대로 매핑
-        // -----------------------------
-        public static DetailResponse fromEntity(JobPosting e, Integer applicantCount) {
-            // 기술스택 이름 리스트
-            List<String> skills = (e.getSkills() == null) ? List.of()
-                    : e.getSkills().stream()
-                    .filter(Objects::nonNull)
-                    .map(JobPostingSkill::getName)
-                    .filter(Objects::nonNull)
-                    .toList();
-
-            // 채용 프로세스 이름 리스트 (orderIndex 정렬)
-            List<String> processes = (e.getRecruitProcesses() == null) ? List.of()
-                    : e.getRecruitProcesses().stream()
-                    .filter(Objects::nonNull)
-                    .sorted(Comparator.comparing(rp -> rp.getOrderIdx() == null ? 0 : rp.getOrderIdx()))
-                    .map(RecruitProcess::getName)
-                    .filter(Objects::nonNull)
-                    .toList();
-
-            return DetailResponse.builder()
-                    .id(e.getId())
-                    .title(e.getTitle())
-                    .employmentType(e.getEmploymentType())
-                    .careerType(e.getCareerType())
-                    .minExperience(e.getMinExperience())
-                    .maxExperience(e.getMaxExperience())
-                    .positionLevel(e.getPositionLevel())
-                    .location(e.getLocation())
-                    .applyStartDate(e.getApplyStartDate())
-                    .applyEndDate(e.getApplyEndDate())
-                    .hireEndDate(e.getHireEndDate())
-                    .headcount(e.getHeadcount())
-                    .applicantCount(applicantCount)
-                    .summary(e.getSummary())
-                    .responsibilities(e.getResponsibilities())
-                    .requirements(e.getRequirements())
-                    .preferred(e.getPreferred())
-                    .techStack(skills)
-                    .recruitProcess(processes)
-                    .salaryType(e.getSalaryType())
-                    .salaryMin(e.getSalaryMin())
-                    .salaryMax(e.getSalaryMax())
-                    .salaryNegotiable(e.getSalaryNegotiable())
-                    .workingHours(e.getWorkingHours())
-                    .benefits(e.getBenefits())
-                    .additionalInfo(e.getAdditionalInfo())
-                    .departmentId(e.getDepartment().getId())
-                    .departmentName(e.getDepartment().getName())
-                    .contactName(e.getContactName())
-                    .contactEmail(e.getContactEmail())
-                    .createdUserId(e.getCreatedUser().getId())
+        public static HeaderResponse fromEntity(JobPosting entity) {
+            List<String> skills = entity.getSkills().stream().map(JobPostingSkill::getName).toList();
+            String status = HeaderResponse.computeStatus(entity.getApplyStartDate(), entity.getHireEndDate());
+            return HeaderResponse.builder()
+                    .id(entity.getId())
+                    .title(entity.getTitle())
+                    .status(status)
+                    .departmentName(entity.getDepartment().getName())
+                    .employmentType(entity.getEmploymentType())
+                    .location(entity.getLocation())
+                    .careerType(entity.getCareerType())
+                    .minExperience(entity.getMinExperience() == 0 ? null : entity.getMinExperience())
+                    .maxExperience(entity.getMaxExperience() == 0 ? null : entity.getMaxExperience())
+                    .skills(skills)
+                    .salaryType(entity.getSalaryType())
+                    .salaryMin(entity.getSalaryMin())
+                    .salaryMax(entity.getSalaryMax())
+                    .SalaryNegotiable(entity.getSalaryNegotiable())
                     .build();
         }
+
+        private static String computeStatus(LocalDateTime start, LocalDateTime end) {
+            LocalDateTime now = LocalDateTime.now();
+            if (now.isBefore(start)) return "예정";
+            if (now.isAfter(end)) return "마감";
+            return "채용중";
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class DetailResponse {
+        //기본 식별자
+        private Long id;
+
+        //기본 회사소개
+        private String summary; //직무 소개
+        private String responsibilities; // 주요 업무
+        private String requirements; // 필수 자격 요건
+        private String preferred; // 우대 사항
+        private String benefits; // 복리후생
+        private String additionalInfo; //기타 안내사항
+
+        //공고 정보
+        private String status; // ex)채용중 , 마감, 예정
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime createDate; //등록일
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime applyStartDate; //접수시작일
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime applyEndDate; //접수마감일
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime hireEndDate; //채용마감일
+
+        private Integer headCount; //모집 인원
+        private Integer applicantCount; //지원자 수
+
+        private List<String> skills;
+        private List<RecruitProcessDto.Read> recruitProcesses;
+
+        private String workingHours;
+        private String location;
+
+        private String contactName;
+        private String contactEmail;
+
+        public static DetailResponse fromEntity(JobPosting entity, Integer applicantCount) {
+            List<String> skills = entity.getSkills().stream().map(JobPostingSkill::getName).toList();
+            String status = HeaderResponse.computeStatus(entity.getApplyStartDate(), entity.getHireEndDate());
+            List<RecruitProcessDto.Read> recruitProcesses = entity.getRecruitProcesses().stream().map(RecruitProcessDto.Read::from).toList();
+
+            return DetailResponse.builder()
+                    .id(entity.getId())
+                    .summary(entity.getSummary())
+                    .responsibilities(entity.getResponsibilities())
+                    .requirements(entity.getRequirements())
+                    .preferred(entity.getPreferred())
+                    .benefits(entity.getBenefits())
+                    .additionalInfo(entity.getAdditionalInfo())
+                    .status(status)
+                    .createDate(entity.getCreatedAt())
+                    .applyStartDate(entity.getApplyStartDate())
+                    .applyEndDate(entity.getApplyEndDate())
+                    .hireEndDate(entity.getHireEndDate())
+                    .headCount(entity.getHeadcount())
+                    .applicantCount(applicantCount)
+                    .skills(skills)
+                    .recruitProcesses(recruitProcesses)
+                    .workingHours(entity.getWorkingHours())
+                    .location(entity.getLocation())
+                    .contactName(entity.getContactName())
+                    .contactEmail(entity.getContactEmail())
+                    .build();
+
+
+        }
+
+
     }
 
 

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
@@ -354,13 +354,13 @@ public class JobPostingDto {
         //공고 정보
         private String status; // ex)채용중 , 마감, 예정
 
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
         private LocalDateTime createDate; //등록일
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
         private LocalDateTime applyStartDate; //접수시작일
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
         private LocalDateTime applyEndDate; //접수마감일
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
         private LocalDateTime hireEndDate; //채용마감일
 
         private Integer headCount; //모집 인원

--- a/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
@@ -81,6 +81,15 @@ public class JobPostingService {
         return JobPostingDto.DetailResponse.fromEntity(jp, applicantCounts);
     }
 
+    //채용공고 헤더(기본정보) 조회요청
+    @Transactional(readOnly = true)
+    public JobPostingDto.HeaderResponse getHeaderDetail(Long id) {
+        JobPosting jobPosting = jobPostingRepository.findById(id)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.JOB_POSTING_NOT_FOUND));
+
+        return JobPostingDto.HeaderResponse.fromEntity(jobPosting);
+    }
+
     @Transactional
     public void updateJobPosting(Long id, JobPostingDto.UpdateRequest request) {
         JobPosting jobPosting = jobPostingRepository.findById(id)


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!
- closes #110

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 채용공고 상세조회에 대한 응답 dto를 분리하였습니다
- 현재 프론트는 채용공고 상세조회에 대하여 채용공고의 기본정보를 담고 있는 header부분과 상세정보를 담고 있는 body부분으로 나누어져 있습니다 이에 따라 header와 body에서 각각 api요청을 하고 필요한 응답을 할 수 있도록 기능을 수정하였습니다

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
