### PR TITLE
fix: pdf파일과 resume를 동시에 저장될수 있게 변경, resume엔티티와 one to one 연결, 이미지 url 변경

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/image/controller/ImageController.java
+++ b/src/main/java/com/halo/core_bridge/api/image/controller/ImageController.java
@@ -18,7 +18,7 @@ public class ImageController {
 
     private final ImageService imageService;
 
-    @PostMapping("/upload")
+    @PostMapping
     public ResponseEntity<BaseResponse> register(
             @RequestParam("file") MultipartFile file,
             @RequestParam("directory") String directory,
@@ -30,7 +30,7 @@ public class ImageController {
     }
 
 
-    @GetMapping("/find/{idx}")
+    @GetMapping("/{idx}")
     public ResponseEntity<BaseResponse<String>> getImage(@PathVariable Long idx) {
             String result = imageService.find(idx);
             return ResponseEntity.ok(BaseResponse.success(result));

--- a/src/main/java/com/halo/core_bridge/api/pdf/controller/PdfContorller.java
+++ b/src/main/java/com/halo/core_bridge/api/pdf/controller/PdfContorller.java
@@ -1,58 +1,54 @@
 package com.halo.core_bridge.api.pdf.controller;
 
 import com.halo.core_bridge.api.pdf.model.dto.PdfDto;
-import com.halo.core_bridge.api.pdf.service.PdfService;
-import com.halo.core_bridge.api.resume.model.dto.ResumeDto;
-import com.halo.core_bridge.api.resume.model.entity.Resume;
-import com.halo.core_bridge.common.exception.BaseException;
+import com.halo.core_bridge.api.pdf.service.LocalPdfService;
+import com.halo.core_bridge.api.users.model.dto.UserDto;
 import com.halo.core_bridge.common.model.BaseResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.File;
 
 @RestController
 @RequestMapping("/api/pdf")
 @RequiredArgsConstructor
 public class PdfContorller {
 
-    private final PdfService pdfService;
+    private final LocalPdfService pdfService;
 
-
-
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<BaseResponse> uploadPdf(
-            @RequestPart("file") MultipartFile file,
-            @RequestParam("resumeId") Long resumeId
-    ) {
-        Long pdfId = pdfService.upload(file, resumeId);
-        return ResponseEntity.ok(BaseResponse.success(pdfId));
-    }
-
-    @GetMapping
-    public ResponseEntity<BaseResponse<PdfDto.PdfResponseDto>> getPdf(
-            @RequestParam("resumeId") Long resumeId
-    ) {
-        PdfDto.PdfResponseDto response = pdfService.findPdf(resumeId);
+    @PostMapping
+    public ResponseEntity<BaseResponse> register(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("pdf_directory") String directory,
+            @RequestParam("resumeId") Long resumeId,
+            @AuthenticationPrincipal UserDto.Auth loginUser
+    ){ PdfDto.UploadResponseDto response = pdfService.uploadPdf(file, directory, resumeId);
+        System.out.println(response);
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 
-    @DeleteMapping
-    public ResponseEntity<BaseResponse<Void>> deletePdf(@RequestParam("resumeId") Long resumeId) {
-        pdfService.deletePdf(resumeId);
-        return ResponseEntity.ok(BaseResponse.success(null));
+    @GetMapping("/find/{idx}")
+    public ResponseEntity<BaseResponse> getPdf(@PathVariable Long idx){
+        String result = "" + pdfService.findByResumeId(idx);
+        return ResponseEntity.ok(BaseResponse.success(result));
     }
 
-    @GetMapping("/download/{id}")
-    public ResponseEntity<Resource> download(@PathVariable("id") Long id) {
-        PdfDto.PdfResponseDto pdf = pdfService.findPdfById(id);
-        Resource resource = pdfService.download(id);
+    @DeleteMapping("/{idx}")
+    public ResponseEntity<BaseResponse<Void>> deletePdf(@PathVariable Long idx){
+        pdfService.deletePdf(idx);
+        return ResponseEntity.ok(BaseResponse.success(null));
+
+    }
+
+    @GetMapping("/download/{resumeid}")
+    public ResponseEntity<Resource> download(@PathVariable("resumeId") Long resumeid) {
+        PdfDto.PdfResponseDto pdf = pdfService.findByResumeId(resumeid);
+        Resource resource = pdfService.downloadPdf(pdf.getId());
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_PDF)
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + pdf.getOriginalFilename() + "\"")

--- a/src/main/java/com/halo/core_bridge/api/pdf/model/dto/PdfDto.java
+++ b/src/main/java/com/halo/core_bridge/api/pdf/model/dto/PdfDto.java
@@ -1,9 +1,7 @@
 package com.halo.core_bridge.api.pdf.model.dto;
 
-
-import com.halo.core_bridge.api.image.model.dto.ImageDto;
-import com.halo.core_bridge.api.image.model.entity.Image;
 import com.halo.core_bridge.api.pdf.model.entity.Pdf;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -23,8 +21,9 @@ public class PdfDto {
         private Long pdfSize;
 
         public static PdfDto.UploadResponseDto from(Pdf entity) {
-            return PdfDto.UploadResponseDto.builder()
+            return UploadResponseDto.builder()
                     .originalName(entity.getOriginalFilename())
+                    .pdfName(entity.getOriginalFilename())
                     .pdfPath(entity.getSavedPath())
                     .pdfSize(entity.getFileSize())
                     .build();
@@ -33,20 +32,23 @@ public class PdfDto {
 
     @Getter
     @Builder
+    @AllArgsConstructor
     public static class PdfResponseDto {
         private Long id;
         private String originalFilename;
         private String savedPath;
-        private String fileUrl;
+        private String contentType;
         private Long fileSize;
+        private Long resumeId;
 
         public static PdfDto.PdfResponseDto from(Pdf entity, String baseUrl) {
-            return PdfDto.PdfResponseDto.builder()
+            return PdfResponseDto.builder()
                     .id(entity.getId())
                     .originalFilename(entity.getOriginalFilename())
                     .savedPath(entity.getSavedPath())
-                    .fileUrl(baseUrl + "/PDF/" + entity.getSavedPath())
                     .fileSize(entity.getFileSize())
+                    .contentType(entity.getContentType())
+                    .resumeId(entity.getResume().getId())
                     .build();
         }
     }

--- a/src/main/java/com/halo/core_bridge/api/pdf/model/entity/Pdf.java
+++ b/src/main/java/com/halo/core_bridge/api/pdf/model/entity/Pdf.java
@@ -1,37 +1,38 @@
 package com.halo.core_bridge.api.pdf.model.entity;
 
 import com.halo.core_bridge.common.model.BaseEntity;
+import com.halo.core_bridge.api.resume.model.entity.Resume;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Pdf extends BaseEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     private String originalFilename;
     private String savedPath;
+    private String contentType;
     private Long fileSize;
-
-    @Column(nullable = false)
     private Boolean isDeleted = false;
 
-    private Long resumeId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
 
     @Builder
-    public Pdf(String originalFilename, String savedPath, Long fileSize, Long resumeId) {
+    public Pdf(String originalFilename, String savedPath, String contentType, Long fileSize, Resume resume) {
         this.originalFilename = originalFilename;
         this.savedPath = savedPath;
+        this.contentType = contentType;
         this.fileSize = fileSize;
+        this.resume = resume;
         this.isDeleted = false;
-        this.resumeId = resumeId;
     }
 
     public void safeDelete() {

--- a/src/main/java/com/halo/core_bridge/api/pdf/repository/PdfRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/pdf/repository/PdfRepository.java
@@ -1,12 +1,16 @@
 package com.halo.core_bridge.api.pdf.repository;
 
 import com.halo.core_bridge.api.pdf.model.entity.Pdf;
+import com.halo.core_bridge.api.resume.model.entity.Resume;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface PdfRepository extends JpaRepository<Pdf, Long> {
-    Optional<Pdf> findByResumeId(Long resumeId);
-    Optional<Pdf> findByResumeIdAndIsDeletedFalse(Long resumeId);
+    Optional<Pdf> findByResume(Resume resume);
+    @Query("SELECT p FROM Pdf p WHERE p.resume.id = :resumeId AND p.isDeleted = false")
+    Optional<Pdf> findByResumeIdAndIsDeletedFalse(@Param("resumeId") Long resumeId);
     Optional<Pdf> findByIdAndIsDeletedFalse(Long id);
 }

--- a/src/main/java/com/halo/core_bridge/api/pdf/service/LocalPdfService.java
+++ b/src/main/java/com/halo/core_bridge/api/pdf/service/LocalPdfService.java
@@ -1,0 +1,104 @@
+package com.halo.core_bridge.api.pdf.service;
+
+import com.halo.core_bridge.api.pdf.model.dto.PdfDto;
+import com.halo.core_bridge.api.pdf.model.entity.Pdf;
+import com.halo.core_bridge.api.pdf.repository.PdfRepository;
+import com.halo.core_bridge.api.resume.model.entity.Resume;
+import com.halo.core_bridge.api.resume.service.ResumeService;
+import com.halo.core_bridge.common.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.File;
+import static com.halo.core_bridge.common.model.BaseResponseStatus.*;
+import static com.halo.core_bridge.utils.FileUploadUtils.*;
+
+@Service
+@RequiredArgsConstructor
+public class LocalPdfService implements PdfService {
+
+    private final PdfRepository pdfRepository;
+    private final ResumeService resumeService;
+
+    @Value("${upload.path}")
+    private String uploadPath;
+
+    @Override
+    public PdfDto.UploadResponseDto uploadPdf(MultipartFile file, String directory, Long resumeId) throws BaseException {
+
+        validatePdfFile(file);
+
+        Resume resume = resumeService.getResumeEntity(resumeId);
+
+        String pdfName = generateFileName(file.getOriginalFilename());
+        String pdfPath = uploadPath + File.separator + directory + File.separator + pdfName;
+        String savedPath = directory + "/" + pdfName;
+
+        try{
+            createDirectoryIfNotExists(uploadPath + "/" + directory);
+            file.transferTo(new File(pdfPath));
+
+            Pdf entity = Pdf.builder()
+                    .originalFilename(file.getOriginalFilename())
+                    .savedPath(savedPath)
+                    .fileSize(file.getSize())
+                    .contentType(file.getContentType())
+                    .resume(resume)
+                    .build();
+
+            pdfRepository.save(entity);
+
+            return PdfDto.UploadResponseDto.builder()
+                    .id(entity.getId())
+                    .originalName(entity.getOriginalFilename())
+                    .pdfName(pdfName)
+                    .pdfPath(savedPath)
+                    .pdfSize(entity.getFileSize())
+                    .build();
+        } catch (Exception e){
+            throw BaseException.from(PDF_UPLOAD_FAILED);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PdfDto.PdfResponseDto findByResumeId(Long resumeId) throws BaseException {
+        Resume resume = resumeService.getResumeEntity(resumeId);
+        Pdf pdf = pdfRepository.findByResume(resume)
+                .orElseThrow(() -> BaseException.from(PDF_NOT_FOUND));
+
+        return PdfDto.PdfResponseDto.builder()
+                .id(pdf.getId())
+                .originalFilename(pdf.getOriginalFilename())
+                .savedPath(pdf.getSavedPath())
+                .contentType(pdf.getContentType())
+                .fileSize(pdf.getFileSize())
+                .resumeId(pdf.getResume().getId())
+                .build();
+    }
+
+    @Transactional
+    @Override
+    public void deletePdf(Long id) throws BaseException {
+        Pdf pdf = pdfRepository.findById(id)
+                .orElseThrow(() -> BaseException.from(PDF_NOT_FOUND));
+        pdf.safeDelete();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Resource downloadPdf(Long id) {
+        Pdf pdf = pdfRepository.findByIdAndIsDeletedFalse(id)
+                .orElseThrow(() -> BaseException.from(PDF_NOT_FOUND));
+        String filePath = uploadPath + File.separator + pdf.getSavedPath();
+        File file = new File(filePath);
+        if (!file.exists()) {
+            throw BaseException.from(PDF_NOT_FOUND);
+        }
+        return new FileSystemResource(file);
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/pdf/service/PdfService.java
+++ b/src/main/java/com/halo/core_bridge/api/pdf/service/PdfService.java
@@ -1,108 +1,17 @@
 package com.halo.core_bridge.api.pdf.service;
 
 import com.halo.core_bridge.api.pdf.model.dto.PdfDto;
-import com.halo.core_bridge.api.pdf.model.entity.Pdf;
-import com.halo.core_bridge.api.pdf.repository.PdfRepository;
 import com.halo.core_bridge.common.exception.BaseException;
-import com.halo.core_bridge.utils.FileUploadUtils;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
 
+public interface PdfService {
+    PdfDto.UploadResponseDto uploadPdf(MultipartFile file, String directory, Long resumeId) throws BaseException;
 
-import java.io.File;
-import java.io.IOException;
+    void deletePdf(Long id) throws BaseException;
 
-import static com.halo.core_bridge.common.model.BaseResponseStatus.*;
+    PdfDto.PdfResponseDto findByResumeId(Long resumeid) throws BaseException;
 
-@Service
-@RequiredArgsConstructor
-public class PdfService {
+    Resource downloadPdf(Long id) throws BaseException;
 
-    private static final String PDF_DIRECTORY = "PDF";
-    private final PdfRepository pdfRepository;
-
-    @Value("${upload.path}")
-    private String uploadPath;
-
-    private final String baseUrl = "http://localhost:8080"; // 실제 서버 URL로 변경 가능
-
-    @Transactional
-    public Long upload(MultipartFile file, Long resumeId) {
-        FileUploadUtils.validatePdfFile(file);
-
-        pdfRepository.findByResumeIdAndIsDeletedFalse(resumeId).ifPresent(existingPdf -> {
-            existingPdf.safeDelete();
-            deleteFileFromDisk(existingPdf.getSavedPath());
-        });
-
-        String savedFileName = FileUploadUtils.generateFileName(file.getOriginalFilename());
-        String savedPath = uploadPath + File.separator + PDF_DIRECTORY + File.separator + savedFileName;
-        try {
-            FileUploadUtils.createDirectoryIfNotExists(uploadPath + File.separator + PDF_DIRECTORY);
-            file.transferTo(new File(savedPath));
-
-            Pdf pdf = Pdf.builder()
-                    .originalFilename(file.getOriginalFilename())
-                    .savedPath(savedFileName)
-                    .fileSize(file.getSize())
-                    .resumeId(resumeId)
-                    .build();
-
-            pdfRepository.save(pdf);
-            return pdf.getId();
-        } catch (IOException e) {
-            throw BaseException.from(PDF_UPLOAD_FAILED);
-        }
-    }
-
-    @Transactional(readOnly = true)
-    public PdfDto.PdfResponseDto findPdf(Long resumeId) {
-        Pdf pdf = pdfRepository.findByResumeIdAndIsDeletedFalse(resumeId)
-                .orElseThrow(() -> BaseException.from(PDF_NOT_FOUND));
-        return PdfDto.PdfResponseDto.from(pdf, baseUrl);
-    }
-
-    @Transactional
-    public void deletePdf(Long resumeId) {
-        Pdf pdf = pdfRepository.findByResumeIdAndIsDeletedFalse(resumeId)
-                .orElseThrow(() -> BaseException.from(PDF_NOT_FOUND));
-        pdf.safeDelete();
-        deleteFileFromDisk(pdf.getSavedPath());
-    }
-
-    @Transactional(readOnly = true)
-    public PdfDto.PdfResponseDto findPdfById(Long id) {
-        Pdf pdf = pdfRepository.findByIdAndIsDeletedFalse(id)
-                .orElseThrow(() -> BaseException.from(PDF_NOT_FOUND));
-        return PdfDto.PdfResponseDto.from(pdf, baseUrl);
-    }
-
-    @Transactional(readOnly = true)
-    public Resource download(Long id) {
-        Pdf pdf = pdfRepository.findByIdAndIsDeletedFalse(id)
-                .orElseThrow(() -> BaseException.from(PDF_NOT_FOUND));
-        String filePath = uploadPath + File.separator + PDF_DIRECTORY + File.separator + pdf.getSavedPath();
-        File file = new File(filePath);
-        if (!file.exists()) {
-            throw BaseException.from(PDF_NOT_FOUND);
-        }
-        return new FileSystemResource(file);
-    }
-
-    private void deleteFileFromDisk(String savedFileName) {
-        try {
-            String filePath = uploadPath + File.separator + PDF_DIRECTORY + File.separator + savedFileName;
-            File file = new File(filePath);
-            if (file.exists()) {
-                file.delete();
-            }
-        } catch (Exception e) {
-            System.err.println("파일 삭제 실패: " + e.getMessage());
-        }
-    }
 }

--- a/src/main/java/com/halo/core_bridge/api/resume/controller/ResumeController.java
+++ b/src/main/java/com/halo/core_bridge/api/resume/controller/ResumeController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.*;
 
 import com.halo.core_bridge.api.resume.contents.SwaggerContents;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import org.springframework.web.multipart.MultipartFile;
+
 import java.util.List;
 
 @Slf4j
@@ -47,9 +49,10 @@ public class ResumeController {
     @PostMapping
     public ResponseEntity<Long> createResume(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestBody ResumeDto.Create dto) {
+            @RequestPart("resume") ResumeDto.Create dto,
+            @RequestPart(value = "file", required = false) MultipartFile file) {
         Long userId = Long.parseLong(userDetails.getUsername());
-        Long resumeId = resumeService.create(dto, userId);
+        Long resumeId = resumeService.create(dto, userId, file);
         return ResponseEntity.ok(resumeId);
     }
 

--- a/src/main/java/com/halo/core_bridge/api/resume/model/entity/Resume.java
+++ b/src/main/java/com/halo/core_bridge/api/resume/model/entity/Resume.java
@@ -4,6 +4,7 @@ import com.halo.core_bridge.api.jobposting.model.entity.JobPosting;
 import com.halo.core_bridge.api.jobposting.model.entity.RecruitProcess;
 import com.halo.core_bridge.api.users.model.entity.User;
 import com.halo.core_bridge.common.model.BaseEntity;
+import com.halo.core_bridge.api.pdf.model.entity.Pdf;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -50,6 +51,9 @@ public class Resume extends BaseEntity {
 
     @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ResumeSkill> resumeSkills = new ArrayList<>();
+
+    @OneToOne(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Pdf pdf;
 
 
     // 채용공고관리(칸반) 데이터 불러오기 위해 다대일 연결

--- a/src/main/java/com/halo/core_bridge/api/resume/service/ResumeService.java
+++ b/src/main/java/com/halo/core_bridge/api/resume/service/ResumeService.java
@@ -1,5 +1,6 @@
 package com.halo.core_bridge.api.resume.service;
 
+import com.halo.core_bridge.api.pdf.repository.PdfRepository;
 import com.halo.core_bridge.api.resume.model.dto.ResumeDto;
 import com.halo.core_bridge.api.resume.model.entity.Resume;
 import com.halo.core_bridge.api.resume.repository.ResumeRepository;
@@ -7,13 +8,18 @@ import com.halo.core_bridge.api.resume.repository.ResumeRepository;
 import com.halo.core_bridge.api.users.service.UserService;
 import com.halo.core_bridge.api.jobposting.model.entity.JobPosting;
 import com.halo.core_bridge.api.users.model.entity.User;
+import com.halo.core_bridge.common.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static com.halo.core_bridge.common.model.BaseResponseStatus.RESUME_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -30,9 +36,13 @@ public class ResumeService {
     private final LanguageService languageService;
     private final OverseasExperienceService overseasExperienceService;
     private final ResumeSkillService resumeSkillService;
+    private final PdfRepository pdfRepository;
+
+    @Value("${upload.path}")
+    private String uploadPath;
 
     @Transactional
-    public Long create(ResumeDto.Create dto, Long userId) {
+    public Long create(ResumeDto.Create dto, Long userId, MultipartFile file) {
 //        JobPosting jobPosting = jobPostingService.read(dto.getJobPostingId());
 //        User user = userService.read(userId);
 
@@ -84,6 +94,8 @@ public class ResumeService {
 
         return saved.getId();
     }
+
+
 
     public ResumeDto.Response read(Long id) {
         Resume resume = resumeRepository.findById(id)
@@ -156,5 +168,11 @@ public class ResumeService {
     public void delete(Long id) {
         resumeRepository.deleteById(id);
         log.info("Resume deleted: {}", id);
+    }
+
+    @Transactional(readOnly = true)
+    public Resume getResumeEntity(Long id) {
+        return resumeRepository.findById(id)
+                .orElseThrow(() -> BaseException.from(RESUME_NOT_FOUND));
     }
 }


### PR DESCRIPTION
# #️⃣연관된 이슈
- closes #13 

# 📝작업 내용
pdf파일과 resume를 동시에 저장될수 있게 변경, resume엔티티와 one to one 연결, 이미지 url 변경

## 스크린샷 (선택)
<img width="863" height="844" alt="스크린샷 2025-10-28 오전 9 29 13" src="https://github.com/user-attachments/assets/b0d3ed86-5cec-4966-92f6-9aed2970a5f0" />
<img width="1041" height="907" alt="스크린샷 2025-10-28 오전 9 29 35" src="https://github.com/user-attachments/assets/37cd3d20-67ad-4945-a50a-afa1685a4e51" />
<img width="650" height="825" alt="스크린샷 2025-10-28 오전 9 30 06" src="https://github.com/user-attachments/assets/4b549093-a19c-4c36-8a39-425b40c91be7" />