### PR TITLE
feat: 지원자가 볼 수 있는 채용 공고 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/jobposting/controller/PublicJobPostingController.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/controller/PublicJobPostingController.java
@@ -1,0 +1,26 @@
+package com.halo.core_bridge.api.jobposting.controller;
+
+import com.halo.core_bridge.api.jobposting.model.dto.PublicJobPostingDto;
+import com.halo.core_bridge.api.jobposting.service.JobPostingPublicService;
+import com.halo.core_bridge.common.model.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/jobs")
+@RequiredArgsConstructor
+public class PublicJobPostingController {
+
+    private final JobPostingPublicService jobPostingPublicService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<Object>> getPublicJobPostingList() {
+
+        PublicJobPostingDto.Jobs jobs = jobPostingPublicService.findAllJobs();
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(jobs));
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/PublicJobPostingDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/PublicJobPostingDto.java
@@ -1,0 +1,70 @@
+package com.halo.core_bridge.api.jobposting.model.dto;
+
+import com.halo.core_bridge.api.jobposting.model.entity.CareerType;
+import com.halo.core_bridge.api.jobposting.model.entity.JobPosting;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+public class PublicJobPostingDto {
+
+    @Getter
+    @Builder
+    public static class Job {
+        private Long id;
+        private String title;
+        private String summary;
+        private String experience;
+        private String location;
+        private String deadline;
+        private String department;
+        private int views;
+
+        public static Job from (JobPosting entity) {
+            long days = ChronoUnit.DAYS.between(LocalDateTime.now().toLocalDate(), entity.getApplyEndDate().toLocalDate());
+            String dDay = days < 0 ? "마감" : "D-" + days;
+
+            String requireExp;
+
+            if (entity.getCareerType().equals(CareerType.EXPERIENCED)) {
+
+                requireExp = CareerType.EXPERIENCED.getLabel() + " ";
+
+                if (entity.getMinExperience() != null) {
+                    requireExp = requireExp + entity.getMinExperience() + "년차 ~ ";
+                }
+
+                if (entity.getMaxExperience() != null) {
+                    requireExp = requireExp + entity.getMaxExperience() + "년차";
+                }
+
+            } else {
+                requireExp = entity.getCareerType().getLabel();
+            }
+
+            return Job.builder()
+                    .id(entity.getId())
+                    .title(entity.getTitle())
+                    .summary(entity.getSummary())
+                    .experience(requireExp)
+                    .location(entity.getLocation())
+                    .deadline(dDay)
+                    .department(entity.getDepartment().getDuty().getJobGroup().getName())
+                    .views(1)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class Jobs {
+        private List<Job> jobs;
+
+        public static Jobs from (List<JobPosting> entities) {
+            return Jobs.builder().jobs(entities.stream().map(Job::from).toList()).build();
+        }
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingPublicService.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingPublicService.java
@@ -1,0 +1,26 @@
+package com.halo.core_bridge.api.jobposting.service;
+
+import com.halo.core_bridge.api.jobposting.model.dto.PublicJobPostingDto;
+import com.halo.core_bridge.api.jobposting.model.entity.JobPosting;
+import com.halo.core_bridge.api.jobposting.repository.JobPostingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class JobPostingPublicService {
+
+    private final JobPostingRepository jobPostingRepository;
+
+    /**
+     * 지원자가 보는 채용 공고 리스트를 조회한다.
+     * @return <code>PublicJobPostingDto.Jobs</code> - 조회 DTO
+     */
+    public PublicJobPostingDto.Jobs findAllJobs() {
+
+        List<JobPosting> jobs = jobPostingRepository.findAll();
+        return PublicJobPostingDto.Jobs.from(jobs);
+    }
+}


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #116 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 지원자가 볼 수 있는 채용 공고 리스트 조회 기능을 구현하였습니다.

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항

* 추후 리스트 요청은 페이징처리 예정입니다.
