### PR TITLE
fix: 지원자 관리에서 지원자 목록 조회 시 발생하는 버그 해결

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/management/model/dto/ManagementDto.java
+++ b/src/main/java/com/halo/core_bridge/api/management/model/dto/ManagementDto.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -57,9 +58,10 @@ public class ManagementDto {
 
             // 경력계산
             double totalYears = resume.getCareers().stream()
-                    .mapToDouble(c -> ChronoUnit.DAYS.between(
-                            c.getStartDate().toLocalDate(),
-                            c.getEndDate().toLocalDate()) / 365.0)
+                    .mapToDouble(career -> {
+                        LocalDate end = (career.getEndDate() != null) ? career.getEndDate().toLocalDate() : LocalDate.now();
+                        return ChronoUnit.DAYS.between(career.getStartDate().toLocalDate(), end) / 365.0;
+                    })
                     .sum();
 
 


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #118 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 지원자 관리 칸반 보드의 지원자 목록 요청 시 응답을 내려주지 못하는 버그를 해결하였습니다.
* 지원자가 현재 다른 회사에 근무 중인 상황에서는 해당 경력의 endDate() 가 `null`로 나오는 상황에서 DTO 응답에 데이터를 저장할 때 `null` 처리를 해주지 않아 해당 버그가 발생하였습니다.

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
