### PR TITLE
feat: 로그아웃 기능, 로그인 성공 시 응답 데이터 추가

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/token/filter/LoginFilter.java
+++ b/src/main/java/com/halo/core_bridge/api/token/filter/LoginFilter.java
@@ -70,7 +70,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
             response.getWriter().write(
                     new ObjectMapper().writeValueAsString(
-                            BaseResponse.success(null)
+                            BaseResponse.success(UserDto.LoginResponse.from(authUser))
                     )
             );
 

--- a/src/main/java/com/halo/core_bridge/api/users/controller/UserController.java
+++ b/src/main/java/com/halo/core_bridge/api/users/controller/UserController.java
@@ -12,6 +12,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -23,6 +26,12 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+
+    @Value("${app.token.access.name}")
+    private String accessToken;
+
+    @Value("${app.token.refresh.name}")
+    private String refreshToken;
 
     @Operation(
             summary = "회원 가입",
@@ -60,5 +69,25 @@ public class UserController {
 
         UserDto.Read findReadUser = userService.findById(auth.getId());
         return ResponseEntity.ok(BaseResponse.success(findReadUser));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponse<Object>> logout() {
+
+        ResponseCookie accessTokenCookie = ResponseCookie.from(this.accessToken, null)
+                .httpOnly(true)
+                .maxAge(0)
+                .path("/")
+                .build();
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from(this.refreshToken, null)
+                .httpOnly(true)
+                .maxAge(0)
+                .path("/")
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header("Set-Cookie", accessTokenCookie.toString(), refreshTokenCookie.toString())
+                .body(BaseResponse.success(null));
     }
 }

--- a/src/main/java/com/halo/core_bridge/api/users/model/dto/UserDto.java
+++ b/src/main/java/com/halo/core_bridge/api/users/model/dto/UserDto.java
@@ -148,4 +148,19 @@ public class UserDto {
                     .build();
         }
     }
+
+    @Getter
+    @Builder
+    public static class LoginResponse {
+
+        private String name;
+        private String role;
+
+        public static LoginResponse from(UserDto.Auth authUser) {
+            return LoginResponse.builder()
+                    .name(authUser.getName())
+                    .role(authUser.getRole())
+                    .build();
+        }
+    }
 }


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #2 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 로그아웃 기능을 구현하였습니다. 로그아웃 요청을 받으면 기존의 AccessToken, RefreshToken 쿠키를 제거하는 로직을 수행합니다. 
* 로그인시 프론트엔드 개발자에 필요한 사용자 일부 정보를 응답 데이터에 추가해주었습니다.

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
