### PR TITLE
refactor: 로그인 성공 응답 DTO 수정

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/users/model/UserRoleType.java
+++ b/src/main/java/com/halo/core_bridge/api/users/model/UserRoleType.java
@@ -1,0 +1,29 @@
+package com.halo.core_bridge.api.users.model;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRoleType {
+
+    ROLE_ADMIN("관리자"),
+    ROLE_APPLICANT("지원자"),
+    ROLE_RECRUITER("채용 담당자"),
+    ROLE_INTERVIEWER("면접관");
+
+    private final String displayName;
+
+    UserRoleType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public static String getDisplayName(String code) {
+
+        for (UserRoleType roleType : values()) {
+            if (roleType.name().equals(code)) {
+                return roleType.getDisplayName();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/users/model/dto/UserDto.java
+++ b/src/main/java/com/halo/core_bridge/api/users/model/dto/UserDto.java
@@ -155,11 +155,13 @@ public class UserDto {
 
         private String name;
         private String role;
+        private String email;
 
         public static LoginResponse from(UserDto.Auth authUser) {
             return LoginResponse.builder()
                     .name(authUser.getName())
                     .role(authUser.getRole())
+                    .email(authUser.getEmail())
                     .build();
         }
     }

--- a/src/main/java/com/halo/core_bridge/api/users/model/dto/UserDto.java
+++ b/src/main/java/com/halo/core_bridge/api/users/model/dto/UserDto.java
@@ -1,6 +1,7 @@
 package com.halo.core_bridge.api.users.model.dto;
 
 import com.halo.core_bridge.api.users.model.Gender;
+import com.halo.core_bridge.api.users.model.UserRoleType;
 import com.halo.core_bridge.api.users.model.entity.User;
 import com.halo.core_bridge.api.users.model.entity.UserRole;
 import jakarta.validation.constraints.*;
@@ -160,7 +161,7 @@ public class UserDto {
         public static LoginResponse from(UserDto.Auth authUser) {
             return LoginResponse.builder()
                     .name(authUser.getName())
-                    .role(authUser.getRole())
+                    .role(UserRoleType.getDisplayName(authUser.getRole()))
                     .email(authUser.getEmail())
                     .build();
         }


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- 로그인 응답 성공 시 담기는 데이터 중 사용자 권한을 코드에서 이름으로 수정하였습니다.

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 스크린샷 (선택)

<img width="723" height="205" alt="image" src="https://github.com/user-attachments/assets/f53d4123-20e9-41f2-b713-502abe04ca5d" />

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
