### PR TITLE
fix: 채용프로세스 상세조회시 순서 반영되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
@@ -375,10 +375,11 @@ public class JobPostingDto {
         private String contactName;
         private String contactEmail;
 
-        public static DetailResponse fromEntity(JobPosting entity, Integer applicantCount) {
+        public static DetailResponse fromEntity(JobPosting entity, List<RecruitProcess> process, Integer applicantCount) {
+
             List<String> skills = entity.getSkills().stream().map(JobPostingSkill::getName).toList();
             String status = HeaderResponse.computeStatus(entity.getApplyStartDate(), entity.getHireEndDate());
-            List<RecruitProcessDto.Read> recruitProcesses = entity.getRecruitProcesses().stream().map(RecruitProcessDto.Read::from).toList();
+            List<RecruitProcessDto.Read> recruitProcesses = process.stream().map(RecruitProcessDto.Read::from).toList();
 
             return DetailResponse.builder()
                     .id(entity.getId())

--- a/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
@@ -74,11 +74,15 @@ public class JobPostingService {
     // 상세조회
     @Transactional(readOnly = true)
     public JobPostingDto.DetailResponse getDetail(Long id) {
+
         JobPosting jp = jobPostingRepository.findById(id)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.JOB_POSTING_NOT_FOUND));
 
+        List<RecruitProcess> jobPostingProcess = recruitProcessRepository.findByJobPosting_IdOrderByOrderIdxAsc(id);
+
         int applicantCounts = resumeRepository.countByJobPostingId(id);
-        return JobPostingDto.DetailResponse.fromEntity(jp, applicantCounts);
+
+        return JobPostingDto.DetailResponse.fromEntity(jp, jobPostingProcess, applicantCounts);
     }
 
     //채용공고 헤더(기본정보) 조회요청


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!
- closes #130 

# 📝작업 내용

채용공고 상세응답 dto 반환시에 orderidx로 오름차순한 해당공고의 프로세스 객체를 리스트에 담은 후 entity -> dto 메소드의 매개변수로 전달

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
