### PR TITLE
feat: 채용공고 dto에 coverLetterTitleRequest dto를 담은 리스트 필드 추가 및 coverLetter서비스 호출

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/jobposting/controller/JobPostingController.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/controller/JobPostingController.java
@@ -1,6 +1,9 @@
 package com.halo.core_bridge.api.jobposting.controller;
 
 
+import com.halo.core_bridge.api.coverLetterTitle.model.dto.CoverLetterTitleDto;
+import com.halo.core_bridge.api.coverLetterTitle.model.entity.CoverLetterTitle;
+import com.halo.core_bridge.api.coverLetterTitle.service.CoverLetterTitleService;
 import com.halo.core_bridge.api.jobposting.contents.SwaggerJobPostingContents;
 import com.halo.core_bridge.api.jobposting.model.dto.JobPostingDto;
 import com.halo.core_bridge.api.jobposting.service.JobPostingService;
@@ -31,6 +34,7 @@ import java.util.List;
 public class JobPostingController {
     private final JobPostingService jobPostingService;
     private final RecruitProcessService recruitProcessService;
+    private final CoverLetterTitleService coverLetterTitleService;
 
     //채용공고 등록
     @Operation(
@@ -75,6 +79,7 @@ public class JobPostingController {
         Long userId = 1L;
         Long jobPostingId = jobPostingService.save(request, userId);
         recruitProcessService.create(request.getRecruitProcess(), jobPostingId);
+        coverLetterTitleService.create(request.getCoverLetterTitles(), jobPostingId);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.success("채용공고 등록완료"));
     }

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
@@ -102,7 +102,8 @@ public class JobPostingDto {
         @Valid
         private List<RecruitProcessDto.Create> recruitProcess;
 
-        @NotEmpty(message = "질문 항목은 최소 1개 이상 입력해야 합니다.")
+        @NotNull(message = "질문 항목 리스트는 비워둘 수 없습니다.")
+        @Size(min = 3, message = "질문 항목은 최소 3개 이상 입력해야 합니다.")
         @Valid
         private List<CoverLetterTitleDto.CoverLetterTitleRequest> coverLetterTitles;
 

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
@@ -1,6 +1,7 @@
 package com.halo.core_bridge.api.jobposting.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.halo.core_bridge.api.coverLetterTitle.model.dto.CoverLetterTitleDto;
 import com.halo.core_bridge.api.jobposting.model.entity.*;
 import com.halo.core_bridge.api.organization.model.entity.Department;
 import com.halo.core_bridge.api.users.model.entity.User;
@@ -100,6 +101,10 @@ public class JobPostingDto {
         @NotEmpty(message = "채용 프로세스는 최소 1개 이상 입력해야 합니다.")
         @Valid
         private List<RecruitProcessDto.Create> recruitProcess;
+
+        @NotEmpty(message = "질문 항목은 최소 1개 이상 입력해야 합니다.")
+        @Valid
+        private List<CoverLetterTitleDto.CoverLetterTitleRequest> coverLetterTitles;
 
         // 급여
         @NotNull(message = "급여 형태는 필수 입력값입니다.")


### PR DESCRIPTION
…les) 추가

# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!
- closes #135 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
채용공고 등록시 반환되는 jobPosting의 index값과 질문지 dto를 함께 coverLetterTitleService.create 호출

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
