### PR TITLE
feat: 특정공고에 대한 지원자 목록 조회

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/jobposting/contents/SwaggerJobPostingContents.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/contents/SwaggerJobPostingContents.java
@@ -268,4 +268,64 @@ public class SwaggerJobPostingContents {
               "result": null
             }
             """;
+
+    public static final String APPLICANT_RESPONSE = """
+            {
+                "success": true,
+                "code": 20000,
+                "message": "요청에 성공하였습니다.",
+                "results": [
+                    {
+                        "name": "강수빈",
+                        "email": "subin.kang@email.com",
+                        "careerType": "경력",
+                        "skills": [
+                            "Java",
+                            "Spring Boot",
+                            "Kubernetes",
+                            "MySQL",
+                            "Redis",
+                            "AWS"
+                        ],
+                        "degree": "학사",
+                        "certificateCount": 2,
+                        "applyDate": "2025-11-01",
+                        "stageName": "1차 기술면접"
+                    },
+                    {
+                        "name": "윤재현",
+                        "email": "jaehyun.yoon@email.com",
+                        "careerType": "경력",
+                        "skills": [
+                            "Java",
+                            "Spring Boot",
+                            "PostgreSQL",
+                            "Docker",
+                            "Jenkins"
+                        ],
+                        "degree": "학사",
+                        "certificateCount": 1,
+                        "applyDate": "2025-11-01",
+                        "stageName": "코딩테스트"
+                    },
+                    {
+                        "name": "황동혁",
+                        "email": "donghyuk.hwang@email.com",
+                        "careerType": "경력",
+                        "skills": [
+                            "Java",
+                            "Spring Boot",
+                            "Redis",
+                            "Kafka",
+                            "MySQL",
+                            "AWS"
+                        ],
+                        "degree": "학사",
+                        "certificateCount": 1,
+                        "applyDate": "2025-11-01",
+                        "stageName": "2차 컬처핏면접"
+                    }
+                ]
+            }
+            """;
 }

--- a/src/main/java/com/halo/core_bridge/api/jobposting/controller/JobPostingController.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/controller/JobPostingController.java
@@ -149,6 +149,7 @@ public class JobPostingController {
         return ResponseEntity.ok(BaseResponse.success(detail)); // HTTP 200 OK
     }
 
+    //채용공고 기본정보 조회
     @Operation(
             summary = "채용공고 기본정보 조회",
             description = "특정 ID의 채용공고의 기본정보를 조회합니다. Header부분"
@@ -178,6 +179,13 @@ public class JobPostingController {
         JobPostingDto.HeaderResponse headerDetail = jobPostingService.getHeaderDetail(id);
         return ResponseEntity.ok(BaseResponse.success(headerDetail));
     }
+
+    //해당채용공고의 지원자 조회
+    @GetMapping("/{id}/applicants")
+    public ResponseEntity<BaseResponse<JobPostingDto.ApplicantResponse>> getJobPostingApplicants(@PathVariable Long id) {
+        jobPostingService.getApplicants(id);
+    }
+
 
 
     //채용공고 수정
@@ -209,6 +217,7 @@ public class JobPostingController {
         return ResponseEntity.ok(BaseResponse.success("수정 완료"));
     }
 
+    //채용공고 삭제
     @DeleteMapping("/{id}")
     @Operation(
             summary = "채용공고 삭제",

--- a/src/main/java/com/halo/core_bridge/api/jobposting/controller/JobPostingController.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/controller/JobPostingController.java
@@ -181,9 +181,25 @@ public class JobPostingController {
     }
 
     //해당채용공고의 지원자 조회
+    @Operation(
+            summary = "채용공고 지원자 조회",
+            description = "특정 ID의 지원자를 전체 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "Applicants Response Example",
+                                    value = SwaggerJobPostingContents.APPLICANT_RESPONSE
+                            )
+                    )
+            )
+    })
     @GetMapping("/{id}/applicants")
-    public ResponseEntity<BaseResponse<JobPostingDto.ApplicantResponse>> getJobPostingApplicants(@PathVariable Long id) {
-        jobPostingService.getApplicants(id);
+    public ResponseEntity<BaseResponse<List<JobPostingDto.ApplicantResponse>>> getJobPostingApplicants(@PathVariable Long id) {
+        List<JobPostingDto.ApplicantResponse> result = jobPostingService.getApplicants(id);
+        return ResponseEntity.ok(BaseResponse.success(result));
     }
 
 

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
@@ -535,6 +535,8 @@ public class JobPostingDto {
     @Getter
     @Builder
     public static class ApplicantResponse {
+        private Long id;
+
         private String name;
         private String email;
         private CareerType careerType;
@@ -549,18 +551,19 @@ public class JobPostingDto {
         public static ApplicantResponse fromEntity(JobPosting jobPosting, Resume resume) {
 
             return JobPostingDto.ApplicantResponse.builder()
-                        .name(resume.getUser().getName())
-                        .email(resume.getUser().getEmail())
-                        .careerType(jobPosting.getCareerType())
-                        .skills(resume.getResumeSkills().stream().map(ResumeSkill::getName).collect(Collectors.toList()))
-                        .degree(resume.getEducations().get(resume.getEducations().size() - 1).getDegree())
-                        .certificateCount(resume.getCertificates().size())
-                        .applyDate(resume.getCreatedAt())
-                        .stageName(resume.getProcess().getName())
-                        .build();
-            }
+                    .id(resume.getId())
+                    .name(resume.getUser().getName())
+                    .email(resume.getUser().getEmail())
+                    .careerType(jobPosting.getCareerType())
+                    .skills(resume.getResumeSkills().stream().map(ResumeSkill::getName).collect(Collectors.toList()))
+                    .degree(resume.getEducations().get(resume.getEducations().size() - 1).getDegree())
+                    .certificateCount(resume.getCertificates().size())
+                    .applyDate(resume.getCreatedAt())
+                    .stageName(resume.getProcess().getName())
+                    .build();
         }
     }
+}
 
 
 

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
@@ -530,5 +530,22 @@ public class JobPostingDto {
         private String additionalInfo;
     }
 
+    @Getter
+    @Builder
+    public static class ApplicantResponse {
+        private String name;
+        private String email;
+        private CareerType careerType;
+        private List<String> skills;
+        private String degree;
+        private int certificateCount;
+        private LocalDateTime applyDate;
+        private String stageName;
+
+        public static ApplicantResponse fromEntity() {
+
+        }
+    }
+
 
 }

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.halo.core_bridge.api.coverLetterTitle.model.dto.CoverLetterTitleDto;
 import com.halo.core_bridge.api.jobposting.model.entity.*;
 import com.halo.core_bridge.api.organization.model.entity.Department;
+import com.halo.core_bridge.api.resume.model.entity.Resume;
+import com.halo.core_bridge.api.resume.model.entity.ResumeSkill;
 import com.halo.core_bridge.api.users.model.entity.User;
 import com.halo.core_bridge.common.model.ColorCode;
 import jakarta.validation.Valid;
@@ -13,7 +15,9 @@ import lombok.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 public class JobPostingDto {
@@ -539,13 +543,26 @@ public class JobPostingDto {
         private List<String> skills;
         private String degree;
         private int certificateCount;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         private LocalDateTime applyDate;
         private String stageName;
 
-        public static ApplicantResponse fromEntity() {
+        public static ApplicantResponse fromEntity(JobPosting jobPosting, Resume resume) {
 
+            return JobPostingDto.ApplicantResponse.builder()
+                        .name(resume.getUser().getName())
+                        .email(resume.getUser().getEmail())
+                        .careerType(jobPosting.getCareerType())
+                        .skills(resume.getResumeSkills().stream().map(ResumeSkill::getName).collect(Collectors.toList()))
+                        .degree(resume.getEducations().get(resume.getEducations().size() - 1).getDegree())
+                        .certificateCount(resume.getCertificates().size())
+                        .applyDate(resume.getCreatedAt())
+                        .stageName(resume.getProcess().getName())
+                        .build();
+            }
         }
     }
 
 
-}
+

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
@@ -7,7 +7,6 @@ import com.halo.core_bridge.api.organization.model.entity.Department;
 import com.halo.core_bridge.api.resume.model.entity.Resume;
 import com.halo.core_bridge.api.resume.model.entity.ResumeSkill;
 import com.halo.core_bridge.api.users.model.entity.User;
-import com.halo.core_bridge.common.model.ColorCode;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.*;
@@ -15,7 +14,6 @@ import lombok.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
@@ -90,6 +90,12 @@ public class JobPostingService {
         return JobPostingDto.DetailResponse.fromEntity(jp, jobPostingProcess, applicantCounts);
     }
 
+    // 해당공고의 지원자 조회
+    @Transactional(readOnly = true)
+    public JobPostingDto.ApplicantResponse getApplicants(Long id) {
+
+    }
+
     //채용공고 헤더(기본정보) 조회요청
     @Transactional(readOnly = true)
     public JobPostingDto.HeaderResponse getHeaderDetail(Long id) {

--- a/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
@@ -1,30 +1,20 @@
 package com.halo.core_bridge.api.jobposting.service;
 
-import com.halo.core_bridge.api.coverLetterTitle.model.entity.CoverLetterTitle;
-import com.halo.core_bridge.api.coverLetterTitle.service.CoverLetterTitleService;
 import com.halo.core_bridge.api.jobposting.model.dto.JobPostingDto;
 import com.halo.core_bridge.api.jobposting.model.entity.JobPosting;
-import com.halo.core_bridge.api.jobposting.model.entity.JobPostingSkill;
 import com.halo.core_bridge.api.jobposting.model.entity.RecruitProcess;
 import com.halo.core_bridge.api.jobposting.repository.JobPostingRepository;
 import com.halo.core_bridge.api.jobposting.repository.JobPostingSkillRepository;
 import com.halo.core_bridge.api.jobposting.repository.RecruitProcessRepository;
-import com.halo.core_bridge.api.organization.model.entity.Department;
-import com.halo.core_bridge.api.organization.service.DepartmentService;
 import com.halo.core_bridge.api.resume.model.entity.Resume;
-import com.halo.core_bridge.api.resume.model.entity.ResumeSkill;
 import com.halo.core_bridge.api.resume.repository.ResumeRepository;
 import com.halo.core_bridge.common.exception.BaseException;
-import com.halo.core_bridge.common.model.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static com.halo.core_bridge.common.model.BaseResponseStatus.JOB_POSTING_NOT_FOUND;
 

--- a/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
@@ -11,6 +11,8 @@ import com.halo.core_bridge.api.jobposting.repository.JobPostingSkillRepository;
 import com.halo.core_bridge.api.jobposting.repository.RecruitProcessRepository;
 import com.halo.core_bridge.api.organization.model.entity.Department;
 import com.halo.core_bridge.api.organization.service.DepartmentService;
+import com.halo.core_bridge.api.resume.model.entity.Resume;
+import com.halo.core_bridge.api.resume.model.entity.ResumeSkill;
 import com.halo.core_bridge.api.resume.repository.ResumeRepository;
 import com.halo.core_bridge.common.exception.BaseException;
 import com.halo.core_bridge.common.model.BaseResponseStatus;
@@ -21,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.halo.core_bridge.common.model.BaseResponseStatus.JOB_POSTING_NOT_FOUND;
 
@@ -92,7 +96,16 @@ public class JobPostingService {
 
     // 해당공고의 지원자 조회
     @Transactional(readOnly = true)
-    public JobPostingDto.ApplicantResponse getApplicants(Long id) {
+    public List<JobPostingDto.ApplicantResponse> getApplicants(Long jobPostingId) {
+        // 해당 공고
+        JobPosting jobPosting = jobPostingRepository.findById(jobPostingId).orElseThrow(() -> BaseException.from(JOB_POSTING_NOT_FOUND));
+
+        // 해당 공고에 속한 이력서
+        List<Resume> resumeList = resumeRepository.findByJobPostingId(jobPostingId);
+
+        // 각각의 이력서 객체를 ApplicantResponse로 변환 후 List에 담아서 반환
+        return resumeList.stream()
+                .map(resume -> JobPostingDto.ApplicantResponse.fromEntity(jobPosting, resume)).toList();
 
     }
 

--- a/src/main/java/com/halo/core_bridge/api/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/resume/repository/ResumeRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
     List<Resume> findByJobPostingIdAndProcessId(Long jobPostingId, Long processId);
 
+    List<Resume> findByJobPostingId(Long jobPostingId);
+
     @Query("SELECT COUNT(r) FROM Resume r WHERE r.jobPosting.id = :jobPostingId")
     int countByJobPostingId(Long jobPostingId);
 


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!
- closes #145 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 스크린샷 (선택)
<img width="766" height="518" alt="image" src="https://github.com/user-attachments/assets/3f7a4d94-c2d5-4fc0-9ef4-b3addb526d5c" />

- 현재 목데이터에는 createdAt이 null로 가서 해당 응답은 null로 들어옵니다. 하지만 실제 사용시 db에 등록하면 자동으로 createAt은 생성되기 때문에 null이 되는 경우는 없습니다.


# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
