### PR TITLE
fix: 비밀번호 변경 링크 URL 수정

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/mail/service/PasswordResetMailService.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/service/PasswordResetMailService.java
@@ -18,6 +18,7 @@ public class PasswordResetMailService extends BaseMailService {
     @Value("${password.reset.redirect.url}")
     private String REDIRECT_LINK;
     private String uuid;
+    private String email;
 
     public PasswordResetMailService(JavaMailSender mailSender, StringRedisTemplate redisTemplate) {
         super(mailSender, MailSend.PASSWORD_RESET_MAIL.getSubject());
@@ -26,6 +27,8 @@ public class PasswordResetMailService extends BaseMailService {
 
     @Override
     public void sendToEmail(String email) {
+
+        this.email = email;
         uuid = createUuid();
         MimeMessage mimeMessage = createMimeMessage(email);
 
@@ -56,15 +59,15 @@ public class PasswordResetMailService extends BaseMailService {
                  </body>
                  </html>
                 """;
-        return String.format(rawView, createURI(uuid));
+        return String.format(rawView, createURI(uuid, email));
     }
 
     private String createUuid() {
         return UUID.randomUUID().toString();
     }
 
-    private String createURI(String uuid) {
-        return REDIRECT_LINK.concat("?token=").concat(uuid);
+    private String createURI(String uuid, String email) {
+        return REDIRECT_LINK.concat("?token=").concat(uuid).concat("&email=").concat(email);
     }
 
     private String createRedisKey(String email) {


### PR DESCRIPTION
기존 링크는 URL의 Parameter에 token값만 전달되었지만 email까지 추가로 전달되도록 수정

# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #155

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 비밀번호 변경 링크를 전송 하는 상황에서 이메일의 정보를 담아주지 않아 클라이언트가 이메일의 정보를 모르는 문제를 해결하였습니다.
* 링크 URL의 파라미터에 token, email 까지 추가하여 전송하는 구조로 변경하였습니다.

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
