### PR TITLE
feat: 면접 장소 삭제 구현

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/interview/controller/InterviewRoomController.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/controller/InterviewRoomController.java
@@ -1,8 +1,11 @@
 package com.halo.core_bridge.api.interview.controller;
 
 import com.halo.core_bridge.api.interview.model.dto.InterviewRoomDto;
+import com.halo.core_bridge.api.interview.repository.InterviewRoomRepository;
 import com.halo.core_bridge.api.interview.service.InterviewRoomService;
+import com.halo.core_bridge.common.exception.BaseException;
 import com.halo.core_bridge.common.model.BaseResponse;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class InterviewRoomController {
 
     private final InterviewRoomService interviewRoomService;
+    private final InterviewRoomRepository interviewRoomRepository;
 
     @PostMapping
     public ResponseEntity<BaseResponse<Object>> createRoom(@RequestBody InterviewRoomDto.Create create) {
@@ -34,5 +38,16 @@ public class InterviewRoomController {
 
         InterviewRoomDto.InterviewRoomList findInterviewRooms = interviewRoomService.findAll();
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(findInterviewRooms));
+    }
+
+    @DeleteMapping("/{interviewRoomId}")
+    public ResponseEntity<BaseResponse<Object>> deleteInterviewRoom(@PathVariable Long interviewRoomId) {
+
+        if (!interviewRoomRepository.existsById(interviewRoomId)) {
+            throw BaseException.from(BaseResponseStatus.NOT_FOUND_INTERVIEW_ROOM);
+        }
+
+        interviewRoomService.deleteById(interviewRoomId);
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success("면접 장소 삭제 완료"));
     }
 }

--- a/src/main/java/com/halo/core_bridge/api/interview/service/InterviewRoomService.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/service/InterviewRoomService.java
@@ -72,4 +72,15 @@ public class InterviewRoomService {
         List<Room> rooms = interviewRoomRepository.findAll();
         return InterviewRoomDto.InterviewRoomList.fromEntity(rooms);
     }
+
+    /**
+     * 면접 장소 삭제
+     * @param interviewRoomId 삭제 하려는 면접 장소의 <code>id</code>
+     */
+    public void deleteById(Long interviewRoomId) {
+
+        // 삭제하려는 장소에 면접일정이 등록되어있는지 확인하는 로직 추후 추가 예정
+
+        interviewRoomRepository.deleteById(interviewRoomId);
+    }
 }


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #180 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 면접 장소를 삭제하는 기능을 구현하였습니다.
* 올바르지 않은 id 삭제 요청 시 예외를 발생시킵니다.

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항

* 면접 일정이 잡혀있다면 삭제가 되지 않도록 추후 조치가 필요합니다.
