### PR TITLE
feat: 관리자가 계정을 추가하는 기능 구현

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/admin/controller/AdminUserController.java
+++ b/src/main/java/com/halo/core_bridge/api/admin/controller/AdminUserController.java
@@ -1,0 +1,27 @@
+package com.halo.core_bridge.api.admin.controller;
+
+import com.halo.core_bridge.api.admin.model.AdminDto;
+import com.halo.core_bridge.api.admin.service.AdminUserService;
+import com.halo.core_bridge.common.model.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<Object>> createUser(@RequestBody AdminDto.UserCreate create) {
+
+        adminUserService.save(create);
+        return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.success("계정이 추가되었습니다."));
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/admin/model/AdminDto.java
+++ b/src/main/java/com/halo/core_bridge/api/admin/model/AdminDto.java
@@ -1,0 +1,33 @@
+package com.halo.core_bridge.api.admin.model;
+
+import com.halo.core_bridge.api.users.model.UserRoleType;
+import com.halo.core_bridge.api.users.model.entity.User;
+import com.halo.core_bridge.api.users.model.entity.UserRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+public class AdminDto {
+
+    @Getter
+    public static class UserCreate {
+
+        @NotBlank(message = "이름을 입력하세요.")
+        private String name;
+
+        @Email
+        @NotBlank(message = "이메일을 입력하세요.")
+        private String email;
+
+        @NotBlank(message = "권한을 선택하세요.")
+        private String roleType;
+
+        public User toEntity(UserRole userRole) {
+            return User.builder()
+                    .name(name)
+                    .email(email)
+                    .userRole(userRole)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/admin/service/AdminUserService.java
+++ b/src/main/java/com/halo/core_bridge/api/admin/service/AdminUserService.java
@@ -1,0 +1,56 @@
+package com.halo.core_bridge.api.admin.service;
+
+import com.halo.core_bridge.api.admin.model.AdminDto;
+import com.halo.core_bridge.api.mail.service.NewAccountPasswordResetMailService;
+import com.halo.core_bridge.api.users.model.entity.User;
+import com.halo.core_bridge.api.users.model.entity.UserRole;
+import com.halo.core_bridge.api.users.repository.UserRepository;
+import com.halo.core_bridge.api.users.service.PasswordService;
+import com.halo.core_bridge.api.users.service.UserRoleService;
+import com.halo.core_bridge.common.exception.BaseException;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserService {
+    
+    private final UserRepository userRepository;
+
+    private final UserRoleService userRoleService;
+    private final PasswordService passwordService;
+    private final NewAccountPasswordResetMailService newAccountPasswordResetMailService;
+
+    /**
+     * 관리자 권한으로 계정을 추가합니다.
+     * @param userCreate 추가할 계졍의 정보
+     * @return 추가된 계정의 ID
+     * @throws BaseException 이메일이 이미 존재하면 예외 발생
+     */
+    @Transactional
+    public Long save(AdminDto.UserCreate userCreate) {
+
+        if (userRepository.existsByEmail(userCreate.getEmail())) {
+            throw BaseException.from(BaseResponseStatus.DUPLICATE_USER_EMAIL);
+        }
+
+        UserRole findUserRole = userRoleService.findByName(userCreate.getRoleType());
+
+        User createUserEntity = userCreate.toEntity(findUserRole);
+
+        String tmpPassword = UUID.randomUUID().toString();
+        passwordService.encodePassword(createUserEntity, tmpPassword);
+        passwordService.changePassword(createUserEntity, tmpPassword);
+
+        User savedUser = userRepository.save(createUserEntity);
+
+        // 비밀번호 변경 링크 이메일 전송
+        newAccountPasswordResetMailService.sendToEmail(savedUser.getEmail());
+
+        return savedUser.getId();
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/mail/model/MailSend.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/model/MailSend.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MailSend {
     AUTH_CODE_MAIL("[CoreBridge] 안녕하세요. 요청하신 인증번호를 보내드립니다.", "AUTH_CODE_MAIL:"),
-    PASSWORD_RESET_MAIL("[CoreBridge] 안녕하세요. 요청하신 비밀번호 재설정 링크를 보내드립니다.", "PASSWORD_RESET_MAIL:");
+    PASSWORD_RESET_MAIL("[CoreBridge] 안녕하세요. 비밀번호 재설정 링크를 보내드립니다.", "PASSWORD_RESET_MAIL:");
 
     private final String subject;
     private final String keyName;

--- a/src/main/java/com/halo/core_bridge/api/mail/service/NewAccountPasswordResetMailService.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/service/NewAccountPasswordResetMailService.java
@@ -1,0 +1,41 @@
+package com.halo.core_bridge.api.mail.service;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+public class NewAccountPasswordResetMailService extends PasswordResetMailService {
+
+    public NewAccountPasswordResetMailService(JavaMailSender mailSender, StringRedisTemplate redisTemplate) {
+        super(mailSender, redisTemplate);
+    }
+
+    @Override
+    protected String createView() {
+        String rawView = """
+                 <html>
+                     <head>
+                     </head>
+                 <body>
+                     <p>
+                         안녕하세요.<br>
+                         계정이 발급되었습니다. 해당 계정은 사용전 비밀번호 재설정이 필요합니다.
+                         아래의 링크에 접속하여 비밀번호를 재설정해주세요.
+                     </p>
+                 <strong style="font-size:20px">
+                     <a href="%s"> 비밀번호 재설정 바로가기 </a>
+                 </strong>
+                 </body>
+                 </html>
+                """;
+        return String.format(rawView, createURI(uuid, email));
+    }
+
+    @Override
+    protected Duration getTimeout() {
+        return null;
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/mail/service/PasswordResetMailService.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/service/PasswordResetMailService.java
@@ -17,8 +17,8 @@ public class PasswordResetMailService extends BaseMailService {
 
     @Value("${password.reset.redirect.url}")
     private String REDIRECT_LINK;
-    private String uuid;
-    private String email;
+    protected String uuid;
+    protected String email;
 
     public PasswordResetMailService(JavaMailSender mailSender, StringRedisTemplate redisTemplate) {
         super(mailSender, MailSend.PASSWORD_RESET_MAIL.getSubject());
@@ -32,9 +32,17 @@ public class PasswordResetMailService extends BaseMailService {
         uuid = createUuid();
         MimeMessage mimeMessage = createMimeMessage(email);
 
-        redisTemplate.opsForValue().set(createRedisKey(email), uuid, Duration.ofMinutes(5));
+        if (getTimeout() == null) {
+            redisTemplate.opsForValue().set(createRedisKey(email), uuid);
+        } else {
+            redisTemplate.opsForValue().set(createRedisKey(email), uuid, getTimeout());
+        }
 
         mailSender.send(mimeMessage);
+    }
+
+    protected Duration getTimeout() {
+        return Duration.ofMinutes(5);
     }
 
     @Override
@@ -66,7 +74,7 @@ public class PasswordResetMailService extends BaseMailService {
         return UUID.randomUUID().toString();
     }
 
-    private String createURI(String uuid, String email) {
+    protected String createURI(String uuid, String email) {
         return REDIRECT_LINK.concat("?token=").concat(uuid).concat("&email=").concat(email);
     }
 

--- a/src/main/java/com/halo/core_bridge/api/users/model/entity/User.java
+++ b/src/main/java/com/halo/core_bridge/api/users/model/entity/User.java
@@ -35,14 +35,14 @@ public class User extends BaseEntity {
 
     private String password;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private LocalDate birth;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String phone;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/halo/core_bridge/api/users/model/entity/UserRole.java
+++ b/src/main/java/com/halo/core_bridge/api/users/model/entity/UserRole.java
@@ -17,9 +17,9 @@ public class UserRole extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String code;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
 }

--- a/src/main/java/com/halo/core_bridge/api/users/repository/UserRoleRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/users/repository/UserRoleRepository.java
@@ -1,0 +1,10 @@
+package com.halo.core_bridge.api.users.repository;
+
+import com.halo.core_bridge.api.users.model.entity.UserRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRoleRepository extends JpaRepository<UserRole, Integer> {
+    Optional<UserRole> findByName(String name);
+}

--- a/src/main/java/com/halo/core_bridge/api/users/service/UserRoleService.java
+++ b/src/main/java/com/halo/core_bridge/api/users/service/UserRoleService.java
@@ -1,0 +1,20 @@
+package com.halo.core_bridge.api.users.service;
+
+import com.halo.core_bridge.api.users.model.entity.UserRole;
+import com.halo.core_bridge.api.users.repository.UserRoleRepository;
+import com.halo.core_bridge.common.exception.BaseException;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserRoleService {
+
+    private final UserRoleRepository userRoleRepository;
+
+    public UserRole findByName(String name) {
+        return userRoleRepository.findByName(name)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.NOT_FOUND_USER_ROLE));
+    }
+}

--- a/src/main/java/com/halo/core_bridge/common/model/BaseResponseStatus.java
+++ b/src/main/java/com/halo/core_bridge/common/model/BaseResponseStatus.java
@@ -89,7 +89,10 @@ public enum BaseResponseStatus {
     // 면접
     DUPLICATE_INTERVIEW_ROOM(false, 75000, "면접 장소는 중복 될 수 없습니다."),
     NOT_FOUND_INTERVIEW_ROOM(false, 75001, "면접 장소를 찾을 수 없습니다."),
-    NOT_PROVIDED_CAPACITY_FOR_OFFLINE_ROOM(false, 75002, "오프라인 장소에는 수용인원이 필요합니다.");
+    NOT_PROVIDED_CAPACITY_FOR_OFFLINE_ROOM(false, 75002, "오프라인 장소에는 수용인원이 필요합니다."),
+
+    // 사용자
+    NOT_FOUND_USER_ROLE(false, 75002, "권한을 찾을 수 없습니다.");
 
     private final boolean isSuccess;
     private final int code;


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #185 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 채용 담당자, 면접관 계정을 추가하는 기능을 구현하였습니다.
* 비밀번호는 암호 값을 임시로 넣어두고 이메일로 전송한 비밀번호 재설정 링크로 접속하여 비밀번호를 재설정 해야만 사용할수 있도록 구현하였습니다.

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
