### PR TITLE
feat: 계정 목록 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,32 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
+//
+//// ### QueryDSL 관련 설정 ###
+//def generated = 'src/main/generated'
+//
+//// querydsl QClass 파일 생성 위치를 지정
+//tasks.withType(JavaCompile).configureEach {
+//    options.getGeneratedSourceOutputDirectory().set(file(generated))
+//}
+//
+//// java source set 에 querydsl QClass 위치 추가
+//sourceSets {
+//    main.java.srcDirs += [ generated ]
+//}
+//
+//// gradle clean 시에 QClass 디렉토리 삭제
+//clean {
+//    delete file(generated)
+//}

--- a/src/main/java/com/halo/core_bridge/api/admin/controller/AdminUserController.java
+++ b/src/main/java/com/halo/core_bridge/api/admin/controller/AdminUserController.java
@@ -1,15 +1,14 @@
 package com.halo.core_bridge.api.admin.controller;
 
-import com.halo.core_bridge.api.admin.model.AdminDto;
 import com.halo.core_bridge.api.admin.service.AdminUserService;
 import com.halo.core_bridge.common.model.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static com.halo.core_bridge.api.admin.model.AdminDto.AccountList;
+import static com.halo.core_bridge.api.admin.model.AdminDto.UserCreate;
 
 @RestController
 @RequestMapping("/api/admin/users")
@@ -19,9 +18,18 @@ public class AdminUserController {
     private final AdminUserService adminUserService;
 
     @PostMapping
-    public ResponseEntity<BaseResponse<Object>> createUser(@RequestBody AdminDto.UserCreate create) {
+    public ResponseEntity<BaseResponse<Object>> createUser(@RequestBody UserCreate create) {
 
         adminUserService.save(create);
         return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.success("계정이 추가되었습니다."));
+    }
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<AccountList>> getAccounts(@RequestParam(name = "type", required = false) String roleType,
+                                                                 @RequestParam(name = "page", defaultValue = "0") int page,
+                                                                 @RequestParam(name = "search", required = false) String keyword) {
+
+        AccountList findAccounts = adminUserService.findAccounts(roleType, page, keyword);
+        return ResponseEntity.ok(BaseResponse.success(findAccounts));
     }
 }

--- a/src/main/java/com/halo/core_bridge/api/admin/model/AdminDto.java
+++ b/src/main/java/com/halo/core_bridge/api/admin/model/AdminDto.java
@@ -1,11 +1,16 @@
 package com.halo.core_bridge.api.admin.model;
 
-import com.halo.core_bridge.api.users.model.UserRoleType;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.halo.core_bridge.api.users.model.entity.User;
 import com.halo.core_bridge.api.users.model.entity.UserRole;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class AdminDto {
 
@@ -27,6 +32,50 @@ public class AdminDto {
                     .name(name)
                     .email(email)
                     .userRole(userRole)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class Account {
+
+        private String name;
+        private String email;
+        private String roleType;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime createdAt;
+
+        public static Account from(User entity) {
+
+            return Account.builder()
+                    .name(entity.getName())
+                    .email(entity.getEmail())
+                    .createdAt(entity.getCreatedAt())
+                    .roleType(entity.getUserRole().getName())
+                    .build();
+
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class AccountList {
+
+        private List<Account> accounts;
+        private int currentPage;
+        private int totalPages;
+        private long totalElements;
+
+        public static AccountList from(Page<User> users) {
+            return AccountList.builder()
+                    .accounts(
+                            users.getContent().stream().map(Account::from).toList()
+                    )
+                    .currentPage(users.getNumber())
+                    .totalElements(users.getTotalElements())
+                    .totalPages(users.getTotalPages())
                     .build();
         }
     }

--- a/src/main/java/com/halo/core_bridge/api/admin/service/AdminUserService.java
+++ b/src/main/java/com/halo/core_bridge/api/admin/service/AdminUserService.java
@@ -4,26 +4,36 @@ import com.halo.core_bridge.api.admin.model.AdminDto;
 import com.halo.core_bridge.api.mail.service.NewAccountPasswordResetMailService;
 import com.halo.core_bridge.api.users.model.entity.User;
 import com.halo.core_bridge.api.users.model.entity.UserRole;
+import com.halo.core_bridge.api.users.repository.UserQueryRepository;
 import com.halo.core_bridge.api.users.repository.UserRepository;
 import com.halo.core_bridge.api.users.service.PasswordService;
 import com.halo.core_bridge.api.users.service.UserRoleService;
 import com.halo.core_bridge.common.exception.BaseException;
 import com.halo.core_bridge.common.model.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
+
+import static com.halo.core_bridge.api.admin.model.AdminDto.*;
 
 @Service
 @RequiredArgsConstructor
 public class AdminUserService {
     
     private final UserRepository userRepository;
+    private final UserQueryRepository userQueryRepository;
 
     private final UserRoleService userRoleService;
     private final PasswordService passwordService;
     private final NewAccountPasswordResetMailService newAccountPasswordResetMailService;
+
+    private final int pageSize = 10;
 
     /**
      * 관리자 권한으로 계정을 추가합니다.
@@ -32,7 +42,7 @@ public class AdminUserService {
      * @throws BaseException 이메일이 이미 존재하면 예외 발생
      */
     @Transactional
-    public Long save(AdminDto.UserCreate userCreate) {
+    public Long save(UserCreate userCreate) {
 
         if (userRepository.existsByEmail(userCreate.getEmail())) {
             throw BaseException.from(BaseResponseStatus.DUPLICATE_USER_EMAIL);
@@ -52,5 +62,23 @@ public class AdminUserService {
         newAccountPasswordResetMailService.sendToEmail(savedUser.getEmail());
 
         return savedUser.getId();
+    }
+
+    /**
+     * 채용 담당자, 면접관 권한을 가진 계정 목록을 조회하는 기능 <br>
+     * @param roleType - 권한 유형, <code>null</code>이면 채용 담당자과 면접관 권한을 모두 가지고 온다.
+     * @return 권한 유형에 따른 계정 목록
+     */
+    @Transactional(readOnly = true)
+    public AccountList findAccounts(String roleType, int page, String keyword) {
+
+        PageRequest pageable = PageRequest.of(page, pageSize, Sort.by("id").descending());
+
+        if (roleType == null) {
+            return AccountList.from(userQueryRepository.searchUsers(List.of("채용 담당자", "면접관"), keyword, pageable));
+        }
+
+        UserRole findUserRole = userRoleService.findByName(roleType);
+        return AccountList.from(userQueryRepository.searchUsers(List.of(findUserRole.getName()), keyword, pageable));
     }
 }

--- a/src/main/java/com/halo/core_bridge/api/users/repository/UserQueryRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/users/repository/UserQueryRepository.java
@@ -1,0 +1,63 @@
+package com.halo.core_bridge.api.users.repository;
+
+import com.halo.core_bridge.api.admin.model.AdminDto;
+import com.halo.core_bridge.api.users.model.entity.QUser;
+import com.halo.core_bridge.api.users.model.entity.QUserRole;
+import com.halo.core_bridge.api.users.model.entity.User;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QUser user = QUser.user;
+    private final QUserRole userRole = QUserRole.userRole;
+
+    public Page<User> searchUsers(List<String> roles, String keyword, Pageable pageable) {
+
+        BooleanBuilder condition = new BooleanBuilder();
+
+        // 역할 조건
+        if (roles != null && !roles.isEmpty()) {
+            condition.and(userRole.name.in(roles));
+        }
+
+        // 검색 조건
+        if (hasText(keyword)) {
+            condition.and(user.name.containsIgnoreCase(keyword)
+                    .or(user.email.containsIgnoreCase(keyword)));
+        }
+
+        List<User> results = jpaQueryFactory
+                .selectFrom(user)
+                .join(user.userRole, userRole).fetchJoin()
+                .where(condition)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = jpaQueryFactory
+                .select(user.count())
+                .from(user)
+                .join(user.userRole, userRole)
+                .where(condition)
+                .fetchOne();
+
+        return new PageImpl<>(results, pageable, total != null ? total : 0);
+
+    }
+
+    private boolean hasText(String str) {
+        return str != null && !str.isBlank();
+    }
+}

--- a/src/main/java/com/halo/core_bridge/config/QueryDslConfig.java
+++ b/src/main/java/com/halo/core_bridge/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.halo.core_bridge.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #187 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 계정 관리에서 계정목록을 조회하는 기능을 구현하였습니다.

1. 전체 조회
2. 필터링
3. 검색

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
