### PR TITLE
feat: 채용 공고 등록 시 면접관 추가 기능 구현

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/admin/model/AdminDto.java
+++ b/src/main/java/com/halo/core_bridge/api/admin/model/AdminDto.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -78,6 +79,27 @@ public class AdminDto {
                     .currentPage(users.getNumber())
                     .totalElements(users.getTotalElements())
                     .totalPages(users.getTotalPages())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class AccountInfiniteList {
+
+        private List<Account> accounts;
+        private int currentPage;
+        private boolean hasNext;
+
+
+        public static AccountInfiniteList from(Slice<User> users) {
+
+            return AccountInfiniteList.builder()
+                    .accounts(
+                            users.getContent().stream().map(Account::from).toList()
+                    )
+                    .currentPage(users.getNumber())
+                    .hasNext(users.hasNext())
                     .build();
         }
     }

--- a/src/main/java/com/halo/core_bridge/api/interview/controller/InterviewController.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/controller/InterviewController.java
@@ -3,6 +3,7 @@ package com.halo.core_bridge.api.interview.controller;
 import com.halo.core_bridge.api.interview.contents.SwaggerInterviewContents;
 import com.halo.core_bridge.api.interview.model.dto.InterviewDto;
 import com.halo.core_bridge.api.interview.service.InterviewService;
+import com.halo.core_bridge.api.users.service.UserService;
 import com.halo.core_bridge.common.model.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -13,10 +14,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static com.halo.core_bridge.api.admin.model.AdminDto.AccountInfiniteList;
 
 @Tag(name = "면접", description = "면접 등록 API")
 @RestController
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class InterviewController {
 
     private final InterviewService interviewService;
+    private final UserService userService;
 
     @Operation(
             summary = "면접 등록",
@@ -53,5 +54,13 @@ public class InterviewController {
     public ResponseEntity<BaseResponse<Object>> createInterview(@RequestBody InterviewDto.Create interviewRequest) {
         interviewService.save(interviewRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.success("면접을 등록하였습니다."));
+    }
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<Object>> getInterviews(@RequestParam(defaultValue = "0") int page,
+                                                              @RequestParam(name = "search", required = false) String keyword) {
+
+        AccountInfiniteList findAccounts = userService.findInfiniteAccounts("면접관", page, keyword);
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success(findAccounts));
     }
 }

--- a/src/main/java/com/halo/core_bridge/api/interview/model/entity/Interviewer.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/model/entity/Interviewer.java
@@ -1,0 +1,27 @@
+package com.halo.core_bridge.api.interview.model.entity;
+
+import com.halo.core_bridge.api.jobposting.model.entity.JobPosting;
+import com.halo.core_bridge.api.users.model.entity.User;
+import com.halo.core_bridge.common.model.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Interviewer extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private JobPosting jobPosting;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+}

--- a/src/main/java/com/halo/core_bridge/api/interview/repository/InterviewerRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/repository/InterviewerRepository.java
@@ -1,0 +1,7 @@
+package com.halo.core_bridge.api.interview.repository;
+
+import com.halo.core_bridge.api.interview.model.entity.Interviewer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewerRepository extends JpaRepository<Interviewer, Long> {
+}

--- a/src/main/java/com/halo/core_bridge/api/interview/service/InterviewerService.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/service/InterviewerService.java
@@ -1,0 +1,41 @@
+package com.halo.core_bridge.api.interview.service;
+
+import com.halo.core_bridge.api.interview.model.entity.Interviewer;
+import com.halo.core_bridge.api.interview.repository.InterviewerRepository;
+import com.halo.core_bridge.api.jobposting.model.entity.JobPosting;
+import com.halo.core_bridge.api.users.model.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewerService {
+
+    private final InterviewerRepository interviewerRepository;
+
+    /**
+     * 특정 채용 공고에 면접관 리스트 배정
+     * @param jobPostingId 채용 공고 Id
+     * @param interviewerIds 면접관 Id 리스트
+     */
+    @Transactional
+    public void saveAll(Long jobPostingId, List<Long> interviewerIds) {
+
+        List<Interviewer> interviewers = interviewerIds.stream().map(interviewerId ->
+                        Interviewer.builder()
+                                .jobPosting(
+                                        JobPosting.builder().id(jobPostingId).build()
+                                )
+                                .user(
+                                        User.builder().id(interviewerId).build()
+                                )
+                                .build()
+                )
+                .toList();
+
+        interviewerRepository.saveAll(interviewers);
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/jobposting/controller/JobPostingController.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/controller/JobPostingController.java
@@ -2,6 +2,7 @@ package com.halo.core_bridge.api.jobposting.controller;
 
 
 import com.halo.core_bridge.api.coverLetterTitle.service.CoverLetterTitleService;
+import com.halo.core_bridge.api.interview.service.InterviewerService;
 import com.halo.core_bridge.api.jobposting.contents.SwaggerJobPostingContents;
 import com.halo.core_bridge.api.jobposting.model.dto.JobPostingDto;
 import com.halo.core_bridge.api.jobposting.service.JobPostingService;
@@ -35,6 +36,7 @@ public class JobPostingController {
     private final JobPostingSkillService jobPostingSkillService;
     private final RecruitProcessService recruitProcessService;
     private final CoverLetterTitleService coverLetterTitleService;
+    private final InterviewerService interviewerService;
 
     //채용공고 등록
     @Operation(
@@ -84,6 +86,9 @@ public class JobPostingController {
         jobPostingSkillService.saveAll(request.getTechStack(), jobPostingId);
         recruitProcessService.create(request.getRecruitProcess(), jobPostingId);
         coverLetterTitleService.create(request.getCoverLetterTitles(), jobPostingId);
+
+        // 면접관 등록
+        interviewerService.saveAll(jobPostingId, request.getInterviewers());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.success("채용공고 등록완료"));
     }

--- a/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/model/dto/JobPostingDto.java
@@ -143,6 +143,10 @@ public class JobPostingDto {
 
         private String additionalInfo;
 
+        @NotNull(message = "면접관을 필수로 등록해야합니다.")
+        @Size(min = 1, message = "한명 이상의 면접관을 선택해주세요.")
+        private List<Long> interviewers;
+
         public JobPosting toEntity(Long createdByUserId) {
             return JobPosting.builder()
                     .title(title)

--- a/src/main/java/com/halo/core_bridge/api/users/repository/UserQueryRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/users/repository/UserQueryRepository.java
@@ -1,16 +1,12 @@
 package com.halo.core_bridge.api.users.repository;
 
-import com.halo.core_bridge.api.admin.model.AdminDto;
 import com.halo.core_bridge.api.users.model.entity.QUser;
 import com.halo.core_bridge.api.users.model.entity.QUserRole;
 import com.halo.core_bridge.api.users.model.entity.User;
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -25,18 +21,7 @@ public class UserQueryRepository {
 
     public Page<User> searchUsers(List<String> roles, String keyword, Pageable pageable) {
 
-        BooleanBuilder condition = new BooleanBuilder();
-
-        // 역할 조건
-        if (roles != null && !roles.isEmpty()) {
-            condition.and(userRole.name.in(roles));
-        }
-
-        // 검색 조건
-        if (hasText(keyword)) {
-            condition.and(user.name.containsIgnoreCase(keyword)
-                    .or(user.email.containsIgnoreCase(keyword)));
-        }
+        BooleanBuilder condition = getBuilderCondition(roles, keyword);
 
         List<User> results = jpaQueryFactory
                 .selectFrom(user)
@@ -55,6 +40,54 @@ public class UserQueryRepository {
 
         return new PageImpl<>(results, pageable, total != null ? total : 0);
 
+    }
+
+    public Slice<User> findInterviewers(List<String> roles, String keyword, Pageable pageable) {
+
+        BooleanBuilder condition = new BooleanBuilder();
+
+        if (roles != null && !roles.isEmpty()) {
+            condition.and(userRole.name.in(roles));
+        }
+
+        // 검색 조건
+        if (hasText(keyword)) {
+            condition.and(user.name.containsIgnoreCase(keyword));
+        }
+
+        // 1. limit + 1 만큼 조회해서 다음 페이지 존재 여부 판단
+        List<User> results = jpaQueryFactory
+                .selectFrom(user)
+                .where(condition)
+                .orderBy(user.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        // 2. hasNext 계산
+        boolean hasNext = false;
+        if (results.size() > pageable.getPageSize()) {
+            hasNext = true;
+            results.remove(pageable.getPageSize()); // 초과분 제거
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+
+    private BooleanBuilder getBuilderCondition(List<String> roles, String keyword) {
+        BooleanBuilder condition = new BooleanBuilder();
+
+        // 역할 조건
+        if (roles != null && !roles.isEmpty()) {
+            condition.and(userRole.name.in(roles));
+        }
+
+        // 검색 조건
+        if (hasText(keyword)) {
+            condition.and(user.name.containsIgnoreCase(keyword)
+                    .or(user.email.containsIgnoreCase(keyword)));
+        }
+        return condition;
     }
 
     private boolean hasText(String str) {

--- a/src/main/java/com/halo/core_bridge/api/users/service/UserService.java
+++ b/src/main/java/com/halo/core_bridge/api/users/service/UserService.java
@@ -1,14 +1,22 @@
 package com.halo.core_bridge.api.users.service;
 
+import com.halo.core_bridge.api.admin.model.AdminDto;
 import com.halo.core_bridge.api.users.model.dto.UserDto;
 import com.halo.core_bridge.api.users.model.entity.User;
+import com.halo.core_bridge.api.users.model.entity.UserRole;
+import com.halo.core_bridge.api.users.repository.UserQueryRepository;
 import com.halo.core_bridge.api.users.repository.UserRepository;
 import com.halo.core_bridge.common.exception.BaseException;
 import com.halo.core_bridge.common.model.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +24,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordService passwordService;
+    private final UserQueryRepository userQueryRepository;
+    private final UserRoleService userRoleService;
 
     public Long save(UserDto.Create createUser) {
         try {
@@ -75,5 +85,25 @@ public class UserService {
         );
 
         return UserDto.Read.from(findUser);
+    }
+
+    /**
+     * 계정을 무한 스크롤로 조회하는 기능
+     * @param roleType 권한 유형, <code>null</code>이면 채용 담당자과 면접관 권한을 모두 가지고 온다.
+     * @param page 페이지 번호
+     * @param keyword 검색어
+     * @return AccountInfiniteList 계정 목록
+     */
+    @Transactional(readOnly = true)
+    public AdminDto.AccountInfiniteList findInfiniteAccounts(String roleType, int page, String keyword) {
+
+        PageRequest pageable = PageRequest.of(page, 10, Sort.by("id").descending());
+
+        if (roleType == null) {
+            return AdminDto.AccountInfiniteList.from(userQueryRepository.findInterviewers(List.of("채용 담당자", "면접관"), keyword, pageable));
+        }
+
+        UserRole findUserRole = userRoleService.findByName(roleType);
+        return AdminDto.AccountInfiniteList.from(userQueryRepository.findInterviewers(List.of(findUserRole.getName()), keyword, pageable));
     }
 }


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #191 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

*  채용 공고 등록 시 면접관을 같이 추가하는 기능을 구현하였습니다.
* 면접관 목록을 먼저 보여주어야하기 때문에 면접관 목록을 조회하는 기능을 구현하였습니다.
* 면접관 목록 조회에서 면접관의 이름을 검색하여 조회하는 기능을 구현하였습니다.
* 면접관 목목 조회를 무한스크롤의 기능으로 제공하기 위해 Slice를 사용하여 조회 기능을 구현하였습니다.

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
