### PR TITLE
feat: 면접 생성 기능 구현

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/interview/model/dto/InterviewDto.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/model/dto/InterviewDto.java
@@ -1,12 +1,10 @@
 package com.halo.core_bridge.api.interview.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.halo.core_bridge.api.interview.model.entity.Interview;
-import com.halo.core_bridge.api.interview.model.entity.Room;
 import com.halo.core_bridge.api.interview.model.enums.InterviewStatus;
+import com.halo.core_bridge.api.interview.model.enums.InterviewType;
 import com.halo.core_bridge.api.jobposting.model.entity.RecruitProcess;
 import com.halo.core_bridge.api.resume.model.entity.Resume;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -21,11 +19,9 @@ public class InterviewDto {
     public static class Create {
 
         @NotNull(message = "면접 시작 시간은 필수입니다.")
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime startDateTime;
 
         @Min(value = 1, message = "면접 소요 시간은 1분 이상이어야 합니다.")
-        @Max(value = 480, message = "면접 소요 시간은 480분 이하이어야 합니다.")
         private int duration;
 
         @NotNull(message = "면접 상태는 필수입니다.")
@@ -36,22 +32,25 @@ public class InterviewDto {
         @NotNull(message = "이력서 ID는 필수입니다.")
         private Long resumeId;
 
-        @NotNull(message = "면접실 ID는 필수입니다.")
-        private Long roomId;
+        @NotNull(message = "면접 장소는 필수입니다.")
+        private String location;
+
+        @NotNull(message = "면접 방식은 필수입니다.")
+        private InterviewType interviewType;
 
         @NotNull(message = "채용 프로세스 ID는 필수입니다.")
         private Long recruiterProcessId;
+
         public Interview toEntity() {
             return Interview.builder()
                     .duration(this.duration)
                     .status(this.status)
                     .description(this.description)
                     .startDateTime(this.startDateTime)
+                    .location(this.location)
+                    .interviewType(this.interviewType)
                     .resume(
                             Resume.builder().id(resumeId).build()
-                    )
-                    .room(
-                            Room.builder().id(roomId).build()
                     )
                     .recruitProcess(
                             RecruitProcess.builder().id(recruiterProcessId).build()

--- a/src/main/java/com/halo/core_bridge/api/interview/model/dto/InterviewRoomDto.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/model/dto/InterviewRoomDto.java
@@ -1,7 +1,7 @@
 package com.halo.core_bridge.api.interview.model.dto;
 
 import com.halo.core_bridge.api.interview.model.entity.Room;
-import com.halo.core_bridge.api.interview.model.enums.RoomType;
+import com.halo.core_bridge.api.interview.model.enums.InterviewType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,7 +14,7 @@ public class InterviewRoomDto {
 
         private String name;
         private String location;
-        private RoomType roomType;
+        private InterviewType interviewType;
         private Integer capacity;
         private String description;
 
@@ -22,7 +22,7 @@ public class InterviewRoomDto {
             return Room.builder()
                     .name(this.name)
                     .location(this.location)
-                    .roomType(this.roomType)
+                    .interviewType(this.interviewType)
                     .capacity(this.capacity)
                     .description(this.description)
                     .build();
@@ -36,7 +36,7 @@ public class InterviewRoomDto {
         private Long id;
         private String name;
         private String location;
-        private RoomType roomType;
+        private InterviewType interviewType;
         private Integer capacity;
         private String description;
 
@@ -45,7 +45,7 @@ public class InterviewRoomDto {
                     .id(entity.getId())
                     .name(entity.getName())
                     .location(entity.getLocation())
-                    .roomType(entity.getRoomType())
+                    .interviewType(entity.getInterviewType())
                     .capacity(entity.getCapacity())
                     .description(entity.getDescription())
                     .build();
@@ -73,7 +73,7 @@ public class InterviewRoomDto {
 
         private String name;
         private String location;
-        private RoomType roomType;
+        private InterviewType interviewType;
         private Integer capacity;
         private String description;
     }

--- a/src/main/java/com/halo/core_bridge/api/interview/model/entity/Interview.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/model/entity/Interview.java
@@ -1,6 +1,7 @@
 package com.halo.core_bridge.api.interview.model.entity;
 
 import com.halo.core_bridge.api.interview.model.enums.InterviewStatus;
+import com.halo.core_bridge.api.interview.model.enums.InterviewType;
 import com.halo.core_bridge.api.jobposting.model.entity.RecruitProcess;
 import com.halo.core_bridge.api.resume.model.entity.Resume;
 import com.halo.core_bridge.common.model.BaseEntity;
@@ -35,11 +36,15 @@ public class Interview extends BaseEntity {
     @Column(nullable = false)
     private String description;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Resume resume;
+    @Column(nullable = false)
+    private String location;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private InterviewType interviewType;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Room room;
+    private Resume resume;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private RecruitProcess  recruitProcess;

--- a/src/main/java/com/halo/core_bridge/api/interview/model/entity/Room.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/model/entity/Room.java
@@ -1,6 +1,6 @@
 package com.halo.core_bridge.api.interview.model.entity;
 
-import com.halo.core_bridge.api.interview.model.enums.RoomType;
+import com.halo.core_bridge.api.interview.model.enums.InterviewType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,7 +25,7 @@ public class Room {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private RoomType roomType;
+    private InterviewType interviewType;
 
     @Column(nullable = false)
     private String description;
@@ -41,8 +41,8 @@ public class Room {
         this.location = newLocation;
     }
 
-    public void changeRoomType(RoomType newRoomType) {
-        this.roomType = newRoomType;
+    public void changeRoomType(InterviewType newInterviewType) {
+        this.interviewType = newInterviewType;
     }
 
     public void changeDescription(String newDescription) {

--- a/src/main/java/com/halo/core_bridge/api/interview/model/enums/InterviewType.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/model/enums/InterviewType.java
@@ -3,14 +3,14 @@ package com.halo.core_bridge.api.interview.model.enums;
 import lombok.Getter;
 
 @Getter
-public enum RoomType {
+public enum InterviewType {
 
     OFFLINE("오프라인"),
     ONLINE("화상");
 
     private final  String name;
 
-    RoomType(String name) {
+    InterviewType(String name) {
         this.name = name;
     }
 }

--- a/src/main/java/com/halo/core_bridge/api/interview/repository/InterviewRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/repository/InterviewRepository.java
@@ -4,4 +4,6 @@ import com.halo.core_bridge.api.interview.model.entity.Interview;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InterviewRepository extends JpaRepository<Interview, Long> {
+
+    boolean existsByRecruitProcess_IdAndResume_Id(Long recruitProcessId, Long resumeId);
 }

--- a/src/main/java/com/halo/core_bridge/api/interview/service/InterviewRoomService.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/service/InterviewRoomService.java
@@ -2,7 +2,7 @@ package com.halo.core_bridge.api.interview.service;
 
 import com.halo.core_bridge.api.interview.model.dto.InterviewRoomDto;
 import com.halo.core_bridge.api.interview.model.entity.Room;
-import com.halo.core_bridge.api.interview.model.enums.RoomType;
+import com.halo.core_bridge.api.interview.model.enums.InterviewType;
 import com.halo.core_bridge.api.interview.repository.InterviewRoomRepository;
 import com.halo.core_bridge.common.exception.BaseException;
 import com.halo.core_bridge.common.model.BaseResponseStatus;
@@ -104,28 +104,28 @@ public class InterviewRoomService {
         if (update.getName() != null)
             findRoom.changeName(update.getName());
 
-        RoomType updatedRoomType = update.getRoomType();
+        InterviewType updatedInterviewType = update.getInterviewType();
 
-        if (updatedRoomType != null) {
+        if (updatedInterviewType != null) {
 
-            if (updatedRoomType == RoomType.ONLINE) {
+            if (updatedInterviewType == InterviewType.ONLINE) {
 
                 findRoom.changeCapacity(null); // 온라인룸은 수용인원 없음
 
-            } else if (updatedRoomType == RoomType.OFFLINE && update.getCapacity() == null) {
+            } else if (updatedInterviewType == InterviewType.OFFLINE && update.getCapacity() == null) {
 
                 throw BaseException.from(BaseResponseStatus.NOT_PROVIDED_CAPACITY_FOR_OFFLINE_ROOM); // 오프라인룸은 수용인원 필수
 
             }
 
-            findRoom.changeRoomType(updatedRoomType);
+            findRoom.changeRoomType(updatedInterviewType);
         }
 
         if (update.getCapacity() != null)
             findRoom.changeCapacity(update.getCapacity());
 
-        if (update.getRoomType() != null)
-            findRoom.changeRoomType(update.getRoomType());
+        if (update.getInterviewType() != null)
+            findRoom.changeRoomType(update.getInterviewType());
 
         if (update.getDescription() != null)
             findRoom.changeDescription(update.getDescription());

--- a/src/main/java/com/halo/core_bridge/api/interview/service/InterviewService.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/service/InterviewService.java
@@ -3,16 +3,42 @@ package com.halo.core_bridge.api.interview.service;
 import com.halo.core_bridge.api.interview.model.dto.InterviewDto;
 import com.halo.core_bridge.api.interview.model.entity.Interview;
 import com.halo.core_bridge.api.interview.repository.InterviewRepository;
+import com.halo.core_bridge.api.resume.model.entity.Resume;
+import com.halo.core_bridge.api.resume.service.ResumeService;
+import com.halo.core_bridge.common.exception.BaseException;
+import com.halo.core_bridge.common.model.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class InterviewService {
 
     private final InterviewRepository interviewRepository;
+    private final ResumeService resumeService;
 
+    @Transactional
     public Long save(InterviewDto.Create create) {
+
+        if (interviewRepository.existsByRecruitProcess_IdAndResume_Id((create.getRecruiterProcessId()), create.getResumeId())) {
+            throw BaseException.from(BaseResponseStatus.ALREADY_SCHEDULED_INTERVIEW);
+        }
+
+        Long resumeProcessId;
+
+        try {
+
+            Resume findResume = resumeService.findById(create.getResumeId());
+            resumeProcessId = findResume.getProcess().getId();
+
+        } catch (RuntimeException e) {
+            throw BaseException.from(BaseResponseStatus.RESUME_NOT_FOUND);
+        }
+
+        if (!resumeProcessId.equals(create.getRecruiterProcessId())) {
+            throw BaseException.from(BaseResponseStatus.RESUME_PROCESS_NOT_MATCH);
+        }
 
         Interview savedInterview = interviewRepository.save(create.toEntity());
         return savedInterview.getId();

--- a/src/main/java/com/halo/core_bridge/common/model/BaseResponseStatus.java
+++ b/src/main/java/com/halo/core_bridge/common/model/BaseResponseStatus.java
@@ -91,6 +91,8 @@ public enum BaseResponseStatus {
     DUPLICATE_INTERVIEW_ROOM(false, 75000, "면접 장소는 중복 될 수 없습니다."),
     NOT_FOUND_INTERVIEW_ROOM(false, 75001, "면접 장소를 찾을 수 없습니다."),
     NOT_PROVIDED_CAPACITY_FOR_OFFLINE_ROOM(false, 75002, "오프라인 장소에는 수용인원이 필요합니다."),
+    ALREADY_SCHEDULED_INTERVIEW(false, 75003, "해당 지원자는 이미 면접을 예약하였습니다"),
+    RESUME_PROCESS_NOT_MATCH(false, 75004, "이력서와 채용 프로세스가 일치하지 않습니다"),
 
     // 사용자
     NOT_FOUND_USER_ROLE(false, 75002, "권한을 찾을 수 없습니다.");


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #193

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 면접을 생성하는 기능을 구현하였습니다.
- 해당 채용 단계에서 지원자의 면접이 이미 생성되어 있다면 생성되지 못하게 예외처리를 진행하였습니다.
- 현재 지원자의 채용 단계외 다른 채용 단계의 면접일정을 생성할 경우 예외처리를 진행하였습니다.

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
