### PR TITLE
feat: 채용공고 삭제시 접수기간 이외에 삭제가능 기능 구현

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
@@ -16,9 +16,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.halo.core_bridge.common.model.BaseResponseStatus.DELETE_NOT_ALLOWED_DURING_APPLICATION;
 import static com.halo.core_bridge.common.model.BaseResponseStatus.JOB_POSTING_NOT_FOUND;
 
 @Service
@@ -171,6 +173,13 @@ public class JobPostingService {
 
     @Transactional
     public void deleteJobPosting(Long id) {
+        JobPosting jobPosting = jobPostingRepository.findById(id).orElseThrow(() -> BaseException.from(JOB_POSTING_NOT_FOUND));
+        LocalDateTime now = LocalDateTime.now();
+
+        if(now.isAfter(jobPosting.getApplyStartDate()) && now.isBefore(jobPosting.getHireEndDate())) {
+            throw BaseException.from(DELETE_NOT_ALLOWED_DURING_APPLICATION);
+        }
+        // 조건 통과 시 삭제
         jobPostingRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/halo/core_bridge/common/model/BaseResponseStatus.java
+++ b/src/main/java/com/halo/core_bridge/common/model/BaseResponseStatus.java
@@ -79,6 +79,7 @@ public enum BaseResponseStatus {
     PDF_NOT_FOUND(false, 70009, "PDF를 찾을 수 없습니다."),
     UNSUPPORTED_FILE_TYPE(false, 70009, "지원하지 않는 형식입니다."),
     FILE_TOO_LARGE(false, 700010, "용량을 초과하였습니다."),
+    DELETE_NOT_ALLOWED_DURING_APPLICATION(false, 700011, "접수 기간 중에는 채용공고를 삭제할 수 없습니다."),
 
     JOB_POSTING_SCHEDULE_NOT_FOUND(false, 71001, "존재하지 않는 공고 일정입니다."),
     PROCESS_SCHEDULE_NOT_FOUND(false, 72001, "존재하지 않는 프로세스 일정입니다."),


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!
- closes #196 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
특정 채용공고에 대한 삭제가 무조건적으로 되는 것이 아닌 접수기간 이외(접수 시작일 이전, 채용마감일 이후)에만 가능하도록 수정

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
