### PR TITLE
fix: 깃 충돌 해결 후 사라진 ResumeRepository 의존성 재추가

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/service/JobPostingService.java
@@ -12,6 +12,7 @@ import com.halo.core_bridge.api.jobposting.repository.JobPostingRepository;
 import com.halo.core_bridge.api.jobposting.repository.JobPostingSkillRepository;
 import com.halo.core_bridge.api.jobposting.repository.JobPostingsQueryRepository;
 import com.halo.core_bridge.api.jobposting.repository.RecruitProcessRepository;
+import com.halo.core_bridge.api.resume.repository.ResumeRepository;
 import com.halo.core_bridge.common.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -36,6 +37,8 @@ public class JobPostingService {
     private final RecruitProcessRepository recruitProcessRepository;
     private final CoverLetterTitleRepository  coverLetterTitleRepository;
     private final JobPostingsQueryRepository jobPostingsQueryRepository;
+    private final ResumeRepository resumeRepository;
+
 
     // 채용공고 등록
     @Transactional


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- closes #205 

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

깃 충돌이 발생하여 해결한 부분에서 컴파일 에러가 발생하였습니다.
JobPostingService가 의존 주입을 받던 ResumeRepository가 삭제되어 컴파일 에러가 발생하였습니다.

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
