### PR TITLE
refactoring: 알림 기능을 redis + spring batch로 고도화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// Spring Batch
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
+
 	// Lombok & DB & Test
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/batch/NotificationBatch.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/batch/NotificationBatch.java
@@ -13,24 +13,24 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
-@RequiredArgsConstructor
-@Log4j2
-public class NotificationBatch {
-
-    private final NotificationRepository repository;
-    private final NotificationService service;
-
-    /** 5분마다 UNSENT 알림 재전송 시도 */
-    @Scheduled(fixedDelay = 300_000)
-    public void resendUnsent() {
-        log.info("[Batch] Start resend...");
-        int page = 0;
-        Page<Notification> result;
-        do {
-            result = repository.findForRetry(List.of(DeliveryStatus.UNSENT), PageRequest.of(page++, 100));
-            result.forEach(service::tryDeliver);
-        } while (!result.isEmpty());
-        log.info("[Batch] Completed resend cycle.");
-    }
-}
+//@Component
+//@RequiredArgsConstructor
+//@Log4j2
+//public class NotificationBatch {
+//
+//    private final NotificationRepository repository;
+//    private final NotificationService service;
+//
+//    /** 5분마다 UNSENT 알림 재전송 시도 */
+//    @Scheduled(fixedDelay = 300_000)
+//    public void resendUnsent() {
+//        log.info("[Batch] Start resend...");
+//        int page = 0;
+//        Page<Notification> result;
+//        do {
+//            result = repository.findForRetry(List.of(DeliveryStatus.UNSENT), PageRequest.of(page++, 100));
+//            result.forEach(service::tryDeliver);
+//        } while (!result.isEmpty());
+//        log.info("[Batch] Completed resend cycle.");
+//    }
+//}

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/controller/NotificationController.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/controller/NotificationController.java
@@ -1,6 +1,8 @@
 package com.halo.core_bridge.api.schedule.notification.controller;
 
 import com.halo.core_bridge.api.schedule.notification.model.dto.NotificationDto;
+import com.halo.core_bridge.api.schedule.notification.model.enums.DeliveryStatus;
+import com.halo.core_bridge.api.schedule.notification.repository.NotificationRepository;
 import com.halo.core_bridge.api.schedule.notification.service.NotificationService;
 import com.halo.core_bridge.api.users.model.UserRoleType;
 import com.halo.core_bridge.api.users.model.dto.UserDto;
@@ -67,6 +69,11 @@ public class NotificationController {
         return ResponseEntity.ok(service.createAndDispatch(request));
     }
 
+    @PostMapping("/hooks/n8n/email-sent/{id}")
+    public ResponseEntity<Void> markEmailSent(@PathVariable Long id) {
+        service.markEmailSent(id);   // 🔥 핵심
+        return ResponseEntity.ok().build();
+    }
 
     // ========== 알림 조회 ==========
 
@@ -136,12 +143,21 @@ public class NotificationController {
         return ResponseEntity.ok().build();
     }
 
+    /**
+     * 미전송 알림 조회 (n8n용)
+     * GET /api/notifications/unsent
+     */
+    @GetMapping("/unsent")
+    public ResponseEntity<List<NotificationDto.Response>> getUnsentNotifications() {
+        List<NotificationDto.Response> unsentNotifications = service.getUnsentNotifications();
+        return ResponseEntity.ok(unsentNotifications);
+    }
+
     // ========== 모니터링 (관리자용) ==========
 
     /**
      * SSE 연결 상태 조회
      * GET /api/notifications/status
-     *
      * 관리자만 접근 가능하도록 설정 필요
      */
     @GetMapping("/status")

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/infra/RedisNotificationPublisher.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/infra/RedisNotificationPublisher.java
@@ -1,0 +1,66 @@
+package com.halo.core_bridge.api.schedule.notification.infra;
+
+import com.halo.core_bridge.api.schedule.notification.model.dto.NotificationDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Redis Pub/Sub 발행자
+ * 알림을 Redis 채널로 발행
+ */
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class RedisNotificationPublisher {
+
+    private final RedisTemplate<String, Object> notificationRedisTemplate;
+    private final ChannelTopic notificationTopic;
+
+    /**
+     * Redis 채널에 알림 발행
+     *
+     * @param notification 발행할 알림
+     * @return 발행 성공 여부
+     */
+    public boolean publish(NotificationDto.Response notification) {
+        try {
+            notificationRedisTemplate.convertAndSend(
+                    notificationTopic.getTopic(),
+                    notification
+            );
+
+            log.info("📤 [Redis Publisher] 알림 발행: id={}, userId={}, title={}",
+                    notification.getId(), notification.getUserId(), notification.getTitle());
+
+            return true;
+
+        } catch (Exception e) {
+            log.error("❌ [Redis Publisher] 발행 실패: id={}, error={}",
+                    notification.getId(), e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * 여러 알림을 한 번에 발행
+     */
+    public void publishBatch(List<NotificationDto.Response> notifications) {
+        int successCount = 0;
+        int failCount = 0;
+
+        for (NotificationDto.Response notification : notifications) {
+            if (publish(notification)) {
+                successCount++;
+            } else {
+                failCount++;
+            }
+        }
+
+        log.info("📤 [Redis Publisher] 배치 발행 완료: success={}, fail={}", successCount, failCount);
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/infra/RedisNotificationSubscriber.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/infra/RedisNotificationSubscriber.java
@@ -1,0 +1,70 @@
+package com.halo.core_bridge.api.schedule.notification.infra;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.core_bridge.api.schedule.notification.model.dto.NotificationDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * Redis Pub/Sub 구독자
+ * Redis로부터 알림을 수신하여 SSE로 전달하고 DB 상태 업데이트
+ */
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class RedisNotificationSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+
+    // ✅ [중앙 집중식 SSE 연결 관리] NotificationService와 공유
+    private final SseEmitterManager emitterManager;
+
+    /**
+     * Redis로부터 메시지 수신 시 호출되는 메서드
+     *
+     * 처리 흐름:
+     * 1. Redis 메시지를 NotificationDto.Response로 역직렬화
+     * 2. SseEmitterManager를 통해 해당 사용자에게 SSE 전송
+     * 3. 전송 결과 로깅
+     *
+     * @param message Redis 메시지
+     * @param pattern 구독 패턴 (현재는 미사용)
+     */
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String body = new String(message.getBody());
+            log.info("📨 [Redis Subscriber] 메시지 수신: {}", body);
+
+            // JSON을 NotificationDto.Response로 역직렬화
+            NotificationDto.Response notification = objectMapper.readValue(
+                    body,
+                    NotificationDto.Response.class
+            );
+
+            // ✅ SseEmitterManager를 통해 해당 사용자에게 알림 전송
+            boolean delivered = emitterManager.sendToUser(
+                    notification.getUserId(),
+                    SseEmitter.event()
+                            .name("notification")
+                            .id(String.valueOf(notification.getId()))
+                            .data(notification)
+            );
+
+            if (delivered) {
+                log.info("✅ [Redis → SSE] 알림 전달 완료: id={}, userId={}, title={}",
+                        notification.getId(), notification.getUserId(), notification.getTitle());
+            } else {
+                log.warn("⚠️ [Redis → SSE] 알림 전달 실패 (연결 없음): id={}, userId={}",
+                        notification.getId(), notification.getUserId());
+            }
+
+        } catch (Exception e) {
+            log.error("❌ [Redis Subscriber] 메시지 처리 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/infra/SseEmitterManager.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/infra/SseEmitterManager.java
@@ -1,0 +1,137 @@
+package com.halo.core_bridge.api.schedule.notification.infra;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@Log4j2
+public class SseEmitterManager {
+
+    private final Map<Long, Set<SseEmitter>> emittersByUser = new ConcurrentHashMap<>();
+
+    /**
+     * Emitter 등록
+     */
+    public void register(Long userId, SseEmitter emitter) {
+        emittersByUser.computeIfAbsent(userId, k -> ConcurrentHashMap.newKeySet()).add(emitter);
+        log.debug("📡 Emitter 등록: userId={}, totalConnections={}", userId, getTotalConnectionCount());
+    }
+
+    /**
+     * Emitter 제거
+     */
+    public void remove(Long userId, SseEmitter emitter) {
+        Set<SseEmitter> emitters = emittersByUser.get(userId);
+        if (emitters != null) {
+            emitters.remove(emitter);
+            if (emitters.isEmpty()) {
+                emittersByUser.remove(userId);
+            }
+        }
+        log.debug("📡 Emitter 제거: userId={}, remainingConnections={}", userId, getTotalConnectionCount());
+    }
+
+    /**
+     * 특정 유저에게 SSE 이벤트 전송
+     */
+    public boolean sendToUser(Long userId, SseEmitter.SseEventBuilder event) {
+        Set<SseEmitter> emitters = emittersByUser.get(userId);
+        if (emitters == null || emitters.isEmpty()) {
+            return false;
+        }
+
+        boolean anyDelivered = false;
+        for (SseEmitter emitter : new ArrayList<>(emitters)) {
+            try {
+                emitter.send(event);
+                anyDelivered = true;
+            } catch (IOException e) {
+                log.warn("💔 Emitter 전송 실패: userId={}, error={}", userId, e.getMessage());
+            } catch (Exception e) {
+                log.error("❌ Emitter 전송 중 예외: userId={}", userId, e);
+            }
+        }
+        return anyDelivered;
+    }
+
+    /**
+     * 특정 유저의 Emitter 목록 조회
+     */
+    public Set<SseEmitter> getEmitters(Long userId) {
+        return emittersByUser.get(userId);
+    }
+
+    /**
+     * 전체 연결 수 조회
+     */
+    public int getTotalConnectionCount() {
+        return emittersByUser.values().stream()
+                .mapToInt(Set::size)
+                .sum();
+    }
+
+    /**
+     * 연결된 유저 수 조회
+     */
+    public int getConnectedUserCount() {
+        return emittersByUser.size();
+    }
+
+    /**
+     * 특정 유저의 연결 수 조회
+     */
+    public int getUserConnectionCount(Long userId) {
+        Set<SseEmitter> emitters = emittersByUser.get(userId);
+        return emitters != null ? emitters.size() : 0;
+    }
+
+    /**
+     * Heartbeat 전송 (모든 연결에 대해)
+     */
+    public Map<String, Integer> sendHeartbeat(String timestamp) {
+        int sent = 0, success = 0, fail = 0;
+
+        for (Map.Entry<Long, Set<SseEmitter>> entry : emittersByUser.entrySet()) {
+            Long userId = entry.getKey();
+            for (SseEmitter em : new ArrayList<>(entry.getValue())) {
+                sent++;
+                try {
+                    em.send(SseEmitter.event()
+                            .name("heartbeat")
+                            .data(timestamp)
+                            .comment("Keep-alive heartbeat"));
+                    success++;
+                } catch (Exception e) {
+                    fail++;
+                    log.warn("💔 Heartbeat 전송 실패: userId={}", userId);
+                }
+            }
+        }
+
+        log.info("💓 Heartbeat 전송 완료: users={}, total={}, success={}, fail={}",
+                getConnectedUserCount(), sent, success, fail);
+
+        return Map.of("sent", sent, "success", success, "fail", fail);
+    }
+
+    /**
+     * 전체 연결 상태 조회
+     */
+    public Map<String, Object> getConnectionStatus() {
+        return Map.of(
+                "connectedUsers", getConnectedUserCount(),
+                "totalConnections", getTotalConnectionCount(),
+                "userConnections", emittersByUser.entrySet().stream()
+                        .collect(java.util.stream.Collectors.toMap(
+                                Map.Entry::getKey, e -> e.getValue().size()
+                        ))
+        );
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/model/entity/Notification.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/model/entity/Notification.java
@@ -43,4 +43,13 @@ public class Notification {
 
     public void markSent() { this.status = DeliveryStatus.SENT; }
     public void increaseRetry() { this.retryCount++; }
+
+    public void markEmailSent() {
+        this.status = DeliveryStatus.EMAIL_SENT;
+    }
+
+    public void markRead() {
+        this.status = DeliveryStatus.READ;
+    }
+
 }

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/model/enums/DeliveryStatus.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/model/enums/DeliveryStatus.java
@@ -2,5 +2,7 @@ package com.halo.core_bridge.api.schedule.notification.model.enums;
 
 public enum DeliveryStatus {
     UNSENT,
-    SENT
+    SENT,
+    READ,
+    EMAIL_SENT
 }

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/repository/NotificationRepository.java
@@ -5,6 +5,7 @@ import com.halo.core_bridge.api.schedule.notification.model.enums.DeliveryStatus
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,15 +14,21 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     /**
-     * 재전송을 위한 UNSENT 알림 조회 (배치용)
+     * ✅ 재전송 대상 알림 조회 (배치용)
+     * - 상태: UNSENT
+     * - 재시도 횟수 제한: retryCount < 5
+     * - timestamp 오름차순 정렬
      */
-    @Query("SELECT n FROM Notification n WHERE n.status IN :statuses ORDER BY n.timestamp ASC")
-    Page<Notification> findForRetry(@Param("statuses") List<DeliveryStatus> statuses, Pageable pageable);
+    @Query("SELECT n FROM Notification n " +
+            "WHERE n.status IN :statuses " +
+            "AND n.retryCount < 5 " +
+            "ORDER BY n.timestamp ASC")
+    Page<Notification> findForRetry(@Param("statuses") List<DeliveryStatus> statuses,
+                                    Pageable pageable);
 
     /**
      * 특정 유저의 미전송 알림 조회 (SSE 재연결 시 사용)
      * - 최근 24시간 이내의 UNSENT 알림만 조회
-     * - 너무 오래된 알림은 제외
      */
     @Query("SELECT n FROM Notification n " +
             "WHERE n.userId = :userId " +
@@ -50,13 +57,17 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     /**
      * 특정 유저의 읽지 않은 알림 수 조회
      */
-    @Query("SELECT COUNT(n) FROM Notification n WHERE n.userId = :userId AND n.status = 'SENT'")
-    long countUnreadByUserId(@Param("userId") Long userId);
+    @Query("SELECT COUNT(n) FROM Notification n WHERE n.userId = :userId AND n.status <> 'READ'")
+    long countUnreadByUserId(Long userId);
+
+
+    List<Notification> findByStatus(DeliveryStatus status);
 
     /**
      * 오래된 SENT 알림 삭제 (30일 이상)
      * - 배치에서 주기적으로 호출하여 DB 정리
      */
+    @Modifying
     @Query("DELETE FROM Notification n WHERE n.status = 'SENT' AND n.timestamp < :before")
     void deleteOldSentNotifications(@Param("before") Long before);
 

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/service/NotificationService.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/service/NotificationService.java
@@ -1,8 +1,10 @@
 package com.halo.core_bridge.api.schedule.notification.service;
 
+import com.halo.core_bridge.api.schedule.notification.infra.SseEmitterManager;
 import com.halo.core_bridge.api.schedule.notification.model.dto.NotificationDto;
 import com.halo.core_bridge.api.schedule.notification.model.entity.Notification;
 import com.halo.core_bridge.api.schedule.notification.model.enums.DeliveryStatus;
+import com.halo.core_bridge.api.schedule.notification.infra.RedisNotificationPublisher;
 import com.halo.core_bridge.api.schedule.notification.repository.NotificationRepository;
 import com.halo.core_bridge.api.users.model.UserRoleType;
 import com.halo.core_bridge.api.users.repository.UserRepository;
@@ -15,8 +17,9 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,43 +29,36 @@ public class NotificationService {
     // ========== 설정 ==========
     private static final long SSE_TIMEOUT_MS = 30 * 60 * 1000L; // 30분
     private static final String EVENT_NAME = "notification";
-    private static final long HEARTBEAT_INTERVAL_MS = 10_000L; // 10초
     private static final int MAX_RETRY_COUNT = 5;
     private static final long OLD_NOTIFICATION_THRESHOLD_DAYS = 30;
 
     private final NotificationRepository repository;
     private final UserRepository userRepository;
 
-    // userId별로 여러 연결을 지원
-    private final Map<Long, Set<SseEmitter>> emittersByUser = new ConcurrentHashMap<>();
+    // ✅ [REDIS 단계 추가]
+    private final RedisNotificationPublisher redisPublisher;
 
-    // 디버그용: Heartbeat 전송 통계
-    private int heartbeatSentCount = 0;
-    private int heartbeatSuccessCount = 0;
-    private int heartbeatFailCount = 0;
+    // ✅ [중앙 집중식 SSE 연결 관리]
+    private final SseEmitterManager emitterManager;
 
     // ========== SSE 구독 관리 ==========
 
     /**
-     * SSE 구독 등록
+     * SSE 구독 엔드포인트 핸들러
+     *
+     * @param userId 구독할 사용자 ID
+     * @param role 사용자 역할 (현재는 미사용, 향후 확장 가능)
+     * @param lastEventId 마지막으로 받은 이벤트 ID (재연결 시 사용)
+     * @return SseEmitter 인스턴스
      */
     public SseEmitter subscribe(Long userId, UserRoleType role, String lastEventId) {
         SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MS);
 
-        // 유저별 emitter 세트에 추가
-        emittersByUser.computeIfAbsent(userId, k -> ConcurrentHashMap.newKeySet()).add(emitter);
-
-        // 연결 종료 시 자동 제거
+        // 연결 종료 시 정리 작업
         Runnable cleanup = () -> {
-            Set<SseEmitter> emitters = emittersByUser.get(userId);
-            if (emitters != null) {
-                emitters.remove(emitter);
-                if (emitters.isEmpty()) {
-                    emittersByUser.remove(userId);
-                }
-            }
+            emitterManager.remove(userId, emitter);
             log.info("SSE 연결 종료: userId={}, 남은 연결={}개",
-                    userId, getConnectedUserCount());
+                    userId, emitterManager.getConnectedUserCount());
         };
 
         emitter.onCompletion(cleanup);
@@ -75,17 +71,21 @@ public class NotificationService {
             cleanup.run();
         });
 
-        // 연결 확인 메시지 전송
+        // Emitter 등록
+        emitterManager.register(userId, emitter);
+
         try {
+            // 초기 연결 확인 메시지 전송
             emitter.send(SseEmitter.event()
                     .name("connected")
                     .data("ok")
                     .comment("SSE connection established"));
 
             log.info("✅ SSE 연결 성공: userId={}, totalUsers={}, totalConnections={}",
-                    userId, getConnectedUserCount(), getTotalConnectionCount());
+                    userId, emitterManager.getConnectedUserCount(),
+                    emitterManager.getTotalConnectionCount());
 
-            // 연결 직후 미전송 알림 재전송
+            // 재연결 시 미전송 알림 재전송
             resendUnsentNotifications(userId);
 
         } catch (IOException e) {
@@ -97,7 +97,10 @@ public class NotificationService {
     }
 
     /**
-     * 특정 유저의 미전송 알림을 재전송
+     * 재연결 시 미전송 알림 재전송
+     * - 최근 24시간 이내의 UNSENT 알림만 조회하여 전송
+     *
+     * @param userId 재전송 대상 사용자 ID
      */
     private void resendUnsentNotifications(Long userId) {
         List<Notification> unsent = repository.findUnsentByUserId(userId);
@@ -109,9 +112,18 @@ public class NotificationService {
 
     // ========== 알림 생성 및 전송 ==========
 
+    /**
+     * 알림 생성 및 발송
+     * - Role 기반: 해당 역할을 가진 모든 사용자에게 발송
+     * - User 기반: 특정 사용자에게만 발송
+     *
+     * @param req 알림 요청 정보
+     * @return 생성된 알림 정보
+     */
     @Transactional
     public NotificationDto.Response createAndDispatch(NotificationDto.Request req) {
         if (req.isRoleBased()) {
+            // Role 기반 알림 발송
             List<Long> userIds = userRepository.findIdsByRole(req.getRole());
             if (userIds.isEmpty()) {
                 log.warn("Role에 해당하는 유저 없음: role={}", req.getRole());
@@ -130,6 +142,7 @@ public class NotificationService {
             return NotificationDto.Response.from(first);
 
         } else {
+            // 개인 알림 발송
             Notification n = repository.save(req.toEntity(req.getUserId()));
             tryDeliver(n);
             log.info("개인 알림 발송: userId={}, title={}", req.getUserId(), req.getTitle());
@@ -137,6 +150,12 @@ public class NotificationService {
         }
     }
 
+    /**
+     * ================================
+     * ✅ 기존 1단계 (단일 서버) 코드
+     * ================================
+     */
+    /*
     @Transactional(noRollbackFor = Exception.class)
     public void tryDeliver(Notification n) {
         if (n.getUserId() == null) {
@@ -171,58 +190,117 @@ public class NotificationService {
 
         repository.save(n);
     }
+    */
 
-    private boolean safeSend(SseEmitter emitter, SseEmitter.SseEventBuilder event) {
-        try {
-            emitter.send(event);
-            return true;
-        } catch (IOException e) {
-            log.warn("Emitter 전송 실패: {}", e.getMessage());
-            return false;
-        } catch (Exception e) {
-            log.error("Emitter 전송 중 예외: {}", e.getMessage(), e);
-            return false;
+    /**
+     * ================================
+     * ✅ [REDIS 단계] 알림 전송 (중복 방지)
+     * ================================
+     *
+     * 알림 전송 프로세스:
+     * 1. Redis Pub/Sub을 통해 모든 서버 인스턴스로 브로드캐스트
+     * 2. 각 서버의 Subscriber가 로컬 SSE 클라이언트에게 전송
+     * 3. DB 상태를 SENT로 업데이트
+     *
+     * ⚠️ 중복 방지: Redis로만 발행 (로컬 직접 전송 제거)
+     * - Redis Subscriber가 모든 서버(자기 자신 포함)에 전송
+     *
+     * @param n 전송할 알림 엔티티
+     */
+    @Transactional(noRollbackFor = Exception.class)
+    public void tryDeliver(Notification n) {
+        if (n.getUserId() == null) {
+            log.warn("userId가 null인 알림: id={}", n.getId());
+            return;
         }
+
+        boolean published = redisPublisher.publish(NotificationDto.Response.from(n));
+
+        if (published) {
+            n.markSent();   // 정상 송신
+        } else {
+            n.increaseRetry();  // 실패 → retry 증가
+        }
+        repository.save(n);
+
+        log.debug("알림 Redis 발행 완료: id={}, userId={}", n.getId(), n.getUserId());
     }
 
     // ========== 알림 조회 ==========
 
+    /**
+     * 특정 사용자의 모든 알림 조회 (최신순)
+     *
+     * @param userId 조회할 사용자 ID
+     * @return 알림 목록
+     */
     @Transactional(readOnly = true)
     public List<NotificationDto.Response> getUserNotifications(Long userId) {
         List<Notification> notifications = repository.findByUserIdOrderByTimestampDesc(userId);
-        return notifications.stream()
-                .map(NotificationDto.Response::from)
-                .toList();
+        return notifications.stream().map(NotificationDto.Response::from).toList();
     }
 
+    /**
+     * 읽지 않은 알림 수 조회
+     *
+     * @param userId 조회할 사용자 ID
+     * @return 읽지 않은 알림 수
+     */
     @Transactional(readOnly = true)
     public long getUnreadCount(Long userId) {
         return repository.countUnreadByUserId(userId);
     }
 
+    // ========== 알림 상태 변경 ==========
+
+    /**
+     * 특정 알림 읽음 처리
+     *
+     * @param notificationId 읽음 처리할 알림 ID
+     * @param userId 요청한 사용자 ID (권한 확인용)
+     */
     @Transactional
     public void markAsRead(Long notificationId, Long userId) {
         repository.findById(notificationId).ifPresent(n -> {
             if (n.getUserId().equals(userId)) {
-                n.markSent();
+                if (n.getStatus() != DeliveryStatus.READ) {
+                    n.markRead();
+                }
                 repository.save(n);
                 log.debug("알림 읽음 처리: id={}, userId={}", notificationId, userId);
             }
         });
     }
 
+    /**
+     * 모든 알림 읽음 처리
+     *
+     * @param userId 요청한 사용자 ID
+     */
     @Transactional
     public void markAllAsRead(Long userId) {
-        List<Notification> notifications = repository.findByUserIdOrderByTimestampDesc(userId);
+        List<Notification> notifications =
+                repository.findByUserIdOrderByTimestampDesc(userId);
+
         notifications.forEach(n -> {
-            if (n.getStatus() == DeliveryStatus.UNSENT) {
-                n.markSent();
+            if (n.getStatus() != DeliveryStatus.READ) {
+                n.markRead();
             }
         });
+
         repository.saveAll(notifications);
         log.info("모든 알림 읽음 처리: userId={}, count={}", userId, notifications.size());
     }
 
+
+    // ========== 알림 삭제 ==========
+
+    /**
+     * 특정 알림 삭제
+     *
+     * @param notificationId 삭제할 알림 ID
+     * @param userId 요청한 사용자 ID (권한 확인용)
+     */
     @Transactional
     public void deleteNotification(Long notificationId, Long userId) {
         repository.findById(notificationId).ifPresent(n -> {
@@ -236,78 +314,58 @@ public class NotificationService {
     // ========== 스케줄러 ==========
 
     /**
-     * Heartbeat (연결 유지)
-     * - 10초마다 실행
-     * - 모든 연결에 heartbeat 전송
+     * Heartbeat 전송 (10초마다)
+     * - 연결 유지 및 비활성 연결 정리
      */
-    @Scheduled(fixedDelay = HEARTBEAT_INTERVAL_MS)
+    @Scheduled(fixedDelay = 10_000L)
     public void sendHeartbeat() {
-        if (emittersByUser.isEmpty()) {
-            // 연결된 사용자가 없을 때는 로그 생략
+        if (emitterManager.getConnectedUserCount() == 0) {
             return;
         }
 
-        heartbeatSentCount = 0;
-        heartbeatSuccessCount = 0;
-        heartbeatFailCount = 0;
-
         String timestamp = Instant.now().toString();
+        Map<String, Integer> stats = emitterManager.sendHeartbeat(timestamp);
 
-        for (Map.Entry<Long, Set<SseEmitter>> entry : emittersByUser.entrySet()) {
-            Long userId = entry.getKey();
-            Set<SseEmitter> emitters = entry.getValue();
-
-            for (SseEmitter em : new ArrayList<>(emitters)) {
-                heartbeatSentCount++;
-
-                boolean sent = safeSend(em, SseEmitter.event()
-                        .name("heartbeat")
-                        .data(timestamp)
-                        .comment("Keep-alive heartbeat"));
-
-                if (sent) {
-                    heartbeatSuccessCount++;
-                } else {
-                    heartbeatFailCount++;
-                    log.warn("💔 Heartbeat 전송 실패: userId={}", userId);
-                }
-            }
-        }
-
-        log.info("💓 Heartbeat 전송 완료: users={}, total={}, success={}, fail={}",
-                emittersByUser.size(), heartbeatSentCount, heartbeatSuccessCount, heartbeatFailCount);
+        // 통계는 SseEmitterManager 내부에서 로깅됨
     }
 
+    @Transactional
+    public void markEmailSent(Long id) {
+        Notification n = repository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Notification not found"));
+
+        n.markEmailSent();      // 엔티티의 비즈니스 메서드 호출
+
+        repository.save(n);
+    }
+
+
     /**
-     * 오래된 알림 자동 삭제
-     * - 매일 새벽 2시에 실행
+     * 오래된 알림 정리 (매일 새벽 2시)
+     * - 30일 이상 지난 SENT 상태 알림 삭제
      */
     @Scheduled(cron = "0 0 2 * * *")
     @Transactional
     public void cleanupOldNotifications() {
         long threshold = System.currentTimeMillis() -
                 (OLD_NOTIFICATION_THRESHOLD_DAYS * 24 * 60 * 60 * 1000L);
-
         try {
             repository.deleteOldSentNotifications(threshold);
-            log.info("오래된 알림 삭제 완료: threshold={}일 전", OLD_NOTIFICATION_THRESHOLD_DAYS);
+            log.info("오래된 알림 삭제 완료: {}일 전", OLD_NOTIFICATION_THRESHOLD_DAYS);
         } catch (Exception e) {
             log.error("오래된 알림 삭제 실패", e);
         }
     }
 
     /**
-     * 전송 실패한 알림 처리
-     * - 매시간 정각에 실행
+     * 재시도 초과 알림 처리 (매 시간 정각)
+     * - retryCount >= 5인 알림 최종 삭제
      */
     @Scheduled(cron = "0 0 * * * *")
     @Transactional
     public void handleFailedNotifications() {
         List<Notification> failed = repository.findFailedNotifications(MAX_RETRY_COUNT);
-
-        if (failed.isEmpty()) {
-            return;
-        }
+        if (failed.isEmpty()) return;
 
         for (Notification n : failed) {
             log.warn("알림 전송 최종 실패: id={}, userId={}, retryCount={}, title={}",
@@ -318,37 +376,23 @@ public class NotificationService {
         log.info("전송 실패 알림 처리 완료: count={}", failed.size());
     }
 
+    public List<NotificationDto.Response> getUnsentNotifications() {
+        List<Notification> unsentList = repository.findByStatus(DeliveryStatus.UNSENT);
+
+        return unsentList.stream()
+                .map(NotificationDto.Response::from)
+                .collect(Collectors.toList());
+    }
+
     // ========== 모니터링 ==========
 
-    public int getConnectedUserCount() {
-        return emittersByUser.size();
-    }
-
-    public int getUserConnectionCount(Long userId) {
-        Set<SseEmitter> emitters = emittersByUser.get(userId);
-        return emitters != null ? emitters.size() : 0;
-    }
-
-    public int getTotalConnectionCount() {
-        return emittersByUser.values().stream()
-                .mapToInt(Set::size)
-                .sum();
-    }
-
+    /**
+     * SSE 연결 상태 조회
+     * - 관리자용 모니터링 API에서 사용
+     *
+     * @return 연결 상태 정보
+     */
     public Map<String, Object> getConnectionStatus() {
-        return Map.of(
-                "connectedUsers", getConnectedUserCount(),
-                "totalConnections", getTotalConnectionCount(),
-                "heartbeatStats", Map.of(
-                        "sent", heartbeatSentCount,
-                        "success", heartbeatSuccessCount,
-                        "fail", heartbeatFailCount
-                ),
-                "userConnections", emittersByUser.entrySet().stream()
-                        .collect(java.util.stream.Collectors.toMap(
-                                Map.Entry::getKey,
-                                e -> e.getValue().size()
-                        ))
-        );
+        return emitterManager.getConnectionStatus();
     }
 }

--- a/src/main/java/com/halo/core_bridge/config/BatchConfig.java
+++ b/src/main/java/com/halo/core_bridge/config/BatchConfig.java
@@ -1,0 +1,163 @@
+package com.halo.core_bridge.config;
+
+import com.halo.core_bridge.api.schedule.notification.model.entity.Notification;
+import com.halo.core_bridge.api.schedule.notification.model.enums.DeliveryStatus;
+import com.halo.core_bridge.api.schedule.notification.repository.NotificationRepository;
+import com.halo.core_bridge.api.schedule.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.data.domain.Sort;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+@Log4j2
+public class BatchConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager txManager;
+    private final JobLauncher jobLauncher;
+
+    private final NotificationRepository repository;
+    private final NotificationService service;
+
+    private static final int CHUNK_SIZE = 100;
+    private static final long OLD_THRESHOLD_DAYS = 30;
+    private static final int MAX_RETRY_COUNT = 5;
+
+    // ===================================================
+    // 1️⃣ 알림 재전송 Step (비동기 병렬 처리)
+    // ===================================================
+    @Bean
+    public Step resendStep() {
+        SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor("resend-task-");
+        executor.setConcurrencyLimit(4); // 병렬 실행 제한
+
+        return new StepBuilder("resendStep", jobRepository)
+                .<Notification, Notification>chunk(CHUNK_SIZE, txManager)
+                .reader(resendReader())
+                .processor(resendProcessor())
+                .writer(resendWriter())
+                .taskExecutor(executor)
+                .build();
+    }
+
+    /**
+     * 알림 재전송 Reader
+     * Pageable은 자동으로 주입되므로 arguments()에는 도메인 인자만 전달.
+     */
+    @Bean
+    public RepositoryItemReader<Notification> resendReader() {
+        return new RepositoryItemReaderBuilder<Notification>()
+                .repository(repository)
+                .methodName("findForRetry") // Repository 메서드 이름
+                .arguments(List.of(List.of(DeliveryStatus.UNSENT))) // ✅ Pageable 제외
+                .pageSize(CHUNK_SIZE)
+                .sorts(Map.of("timestamp", Sort.Direction.ASC))
+                .name("resendReader")
+                .build();
+    }
+
+    /**
+     * 알림 재전송 Processor
+     * 실패 시 retryCount 증가 로직은 NotificationService 내부에 포함되어야 함.
+     */
+    @Bean
+    public ItemProcessor<Notification, Notification> resendProcessor() {
+        return item -> {
+            service.tryDeliver(item);
+            return item;
+        };
+    }
+
+    /**
+     * 알림 재전송 Writer
+     */
+    @Bean
+    public ItemWriter<Notification> resendWriter() {
+        return items -> {
+            repository.saveAll(items);
+            log.info("🔁 [Batch] 재전송 완료 {}건", items.size());
+        };
+    }
+
+    // ===================================================
+    // 2️⃣ 오래된 알림 정리 Step (단일 스레드)
+    // ===================================================
+    @Bean
+    public Step cleanupStep() {
+        return new StepBuilder("cleanupStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    long threshold = System.currentTimeMillis()
+                            - (OLD_THRESHOLD_DAYS * 24 * 60 * 60 * 1000L);
+                    repository.deleteOldSentNotifications(threshold);
+                    log.info("🧹 [Batch] 오래된 알림 정리 완료 (기준일 {}일)", OLD_THRESHOLD_DAYS);
+                    return RepeatStatus.FINISHED;
+                }, txManager)
+                .build();
+    }
+
+    // ===================================================
+    // 3️⃣ 재시도 초과 실패 처리 Step
+    // ===================================================
+    @Bean
+    public Step failedCleanupStep() {
+        return new StepBuilder("failedCleanupStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    List<Notification> failed = repository.findFailedNotifications(MAX_RETRY_COUNT);
+                    if (!failed.isEmpty()) {
+                        failed.forEach(n -> log.warn("❌ 재시도 초과 알림 삭제: id={}, userId={}, retryCount={}, title={}",
+                                n.getId(), n.getUserId(), n.getRetryCount(), n.getTitle()));
+                        repository.deleteAll(failed);
+                        log.info("🧾 [Batch] 재시도 초과 알림 삭제 완료 count={}", failed.size());
+                    }
+                    return RepeatStatus.FINISHED;
+                }, txManager)
+                .build();
+    }
+
+    // ===================================================
+    // 4️⃣ 통합 Job 구성
+    // ===================================================
+    @Bean
+    public Job notificationMaintenanceJob() {
+        return new JobBuilder("notificationMaintenanceJob", jobRepository)
+                .start(resendStep())
+                .next(cleanupStep())
+                .next(failedCleanupStep())
+                .build();
+    }
+
+    // ===================================================
+    // 5️⃣ 스케줄러 (5분마다 실행)
+    // ===================================================
+    @Scheduled(fixedDelay = 300_000)
+    public void runJob() throws Exception {
+        log.info("🚀 [Spring Batch] Notification Maintenance Job 실행 시작");
+
+        JobParameters params = new JobParametersBuilder()
+                .addLong("timestamp", Instant.now().toEpochMilli())
+                .toJobParameters();
+
+        jobLauncher.run(notificationMaintenanceJob(), params);
+    }
+}

--- a/src/main/java/com/halo/core_bridge/config/RedisConfig.java
+++ b/src/main/java/com/halo/core_bridge/config/RedisConfig.java
@@ -1,6 +1,9 @@
 package com.halo.core_bridge.config;
 
-//import com.halo.core_bridge.api.schedule.notification.subscriber.RedisNotificationSubscriber;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.halo.core_bridge.api.schedule.notification.infra.RedisNotificationSubscriber;
 import com.halo.core_bridge.api.token.refresh.model.dto.RefreshTokenDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,7 +23,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @RequiredArgsConstructor
 public class RedisConfig {
 
-//    private final RedisNotificationSubscriber redisNotificationSubscriber;
+    private final RedisNotificationSubscriber redisNotificationSubscriber;
 
     @Value("${redis.host}")
     private String host;
@@ -55,30 +58,55 @@ public class RedisConfig {
         return redisTemplate;
     }
 
-    /*
-    // notifications 채널
+    // ✅ Notification 용 RedisTemplate (JSON 직렬화)
+    @Bean
+    public RedisTemplate<String, Object> notificationRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        // ✅ JavaTimeModule 등록된 ObjectMapper 생성
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // ✅ 권장 직렬화기: GenericJackson2JsonRedisSerializer
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(serializer);
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(serializer);
+
+        redisTemplate.afterPropertiesSet();
+        return redisTemplate;
+    }
+
+    // ✅ 알림 채널
     @Bean
     public ChannelTopic notificationTopic() {
-        return new ChannelTopic("notifications");
+        return new ChannelTopic("notification_channel");
     }
 
-    // Redis 메시지 수신용 listenerAdapter
+    // ✅ MessageListenerAdapter - Subscriber의 onMessage 메서드 연결
     @Bean
-    public MessageListenerAdapter listenerAdapter() {
-        return new MessageListenerAdapter(redisNotificationSubscriber);
+    public MessageListenerAdapter messageListenerAdapter() {
+        return new MessageListenerAdapter(redisNotificationSubscriber, "onMessage");
     }
 
-    // Redis Pub/Sub 리스너 컨테이너 구성
+    // ✅ 구독 컨테이너 (Subscriber를 채널에 등록)
     @Bean
-    public RedisMessageListenerContainer redisContainer(
+    public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory connectionFactory,
-            MessageListenerAdapter listenerAdapter,
+            MessageListenerAdapter messageListenerAdapter,
             ChannelTopic notificationTopic
     ) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
-        container.addMessageListener(listenerAdapter, notificationTopic);
+
+        // ✅ 핵심: MessageListenerAdapter를 notificationTopic에 등록
+        container.addMessageListener(messageListenerAdapter, notificationTopic);
+
         return container;
     }
-    */
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,11 @@ spring:
     driver-class-name: org.mariadb.jdbc.Driver
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+  batch:
+    job:
+      enabled: false              # Job 자동 실행 방지
+    jdbc:
+      initialize-schema: never
   mail:
     host: smtp.gmail.com
     port: 587


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

Spring Batch 적용, Redis 도입

5분마다 스케줄러 실행
   ↓
Notification Maintenance Job 실행
   ↓
[1] resendStep (미전송 알림 재전송)
   ↓
[2] cleanupStep (30일 지난 알림 삭제)
   ↓
[3] failedCleanupStep (retry 5회 초과 삭제)


Redis 도입 후,

DB I/O 대폭 감소, 멀티 인스턴스 환경에서 메시지 브로드캐스트 가능, 메시지 전달 지연 없음 등

## 스크린샷 (선택)

# Redis 도입 전

<img width="692" height="172" alt="image" src="https://github.com/user-attachments/assets/a5b80aa2-fd9c-46d2-8508-74322979c028" />

# Redis 도입 후

<img width="766" height="149" alt="image" src="https://github.com/user-attachments/assets/53b37e10-faae-453f-bc0d-87758b886d6a" />


# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
