### PR TITLE
refactoring: n8n을 위한 endpoint 추가

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/controller/NotificationController.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/controller/NotificationController.java
@@ -1,8 +1,6 @@
 package com.halo.core_bridge.api.schedule.notification.controller;
 
 import com.halo.core_bridge.api.schedule.notification.model.dto.NotificationDto;
-import com.halo.core_bridge.api.schedule.notification.model.enums.DeliveryStatus;
-import com.halo.core_bridge.api.schedule.notification.repository.NotificationRepository;
 import com.halo.core_bridge.api.schedule.notification.service.NotificationService;
 import com.halo.core_bridge.api.users.model.UserRoleType;
 import com.halo.core_bridge.api.users.model.dto.UserDto;
@@ -23,12 +21,10 @@ public class NotificationController {
 
     private final NotificationService service;
 
-    // ========== SSE 구독 ==========
+    // =====================================================
+    // 1. SSE 구독
+    // =====================================================
 
-    /**
-     * SSE 구독 엔드포인트
-     * GET /api/notifications/subscribe
-     */
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(
             @AuthenticationPrincipal UserDto.Auth auth,
@@ -42,19 +38,16 @@ public class NotificationController {
         return service.subscribe(auth.getId(), roleEnum, lastEventId);
     }
 
-    // ========== 알림 생성 및 전송 ==========
+    // =====================================================
+    // 2. 알림 생성 및 발송
+    // =====================================================
 
-    /**
-     * 알림 생성 및 전송
-     * POST /api/notifications
-     */
     @PostMapping
     public ResponseEntity<NotificationDto.Response> send(
             @AuthenticationPrincipal UserDto.Auth auth,
             @RequestBody NotificationDto.Request request) {
 
-        if (auth == null) {
-            // 부하테스트나 비로그인 요청용 기본값
+        if (auth == null) { // 부하테스트
             request.setUserId(1L);
             request.setSenderRole(UserRoleType.ROLE_ADMIN);
         } else {
@@ -69,99 +62,88 @@ public class NotificationController {
         return ResponseEntity.ok(service.createAndDispatch(request));
     }
 
+    // =====================================================
+    // 3. n8n 콜백: 이메일 발송 성공
+    // =====================================================
+
     @PostMapping("/hooks/n8n/email-sent/{id}")
     public ResponseEntity<Void> markEmailSent(@PathVariable Long id) {
-        service.markEmailSent(id);   // 🔥 핵심
+        service.markEmailSent(id);
         return ResponseEntity.ok().build();
     }
 
-    // ========== 알림 조회 ==========
+    // =====================================================
+    // 4. 조회
+    // =====================================================
 
-    /**
-     * 내 알림 목록 조회
-     * GET /api/notifications
-     */
     @GetMapping
     public ResponseEntity<List<NotificationDto.Response>> getMyNotifications(
             @AuthenticationPrincipal UserDto.Auth auth) {
-
-        List<NotificationDto.Response> notifications = service.getUserNotifications(auth.getId());
-        return ResponseEntity.ok(notifications);
+        return ResponseEntity.ok(service.getUserNotifications(auth.getId()));
     }
 
-    /**
-     * 읽지 않은 알림 수 조회
-     * GET /api/notifications/unread/count
-     */
     @GetMapping("/unread/count")
     public ResponseEntity<Map<String, Long>> getUnreadCount(
             @AuthenticationPrincipal UserDto.Auth auth) {
-
         long count = service.getUnreadCount(auth.getId());
         return ResponseEntity.ok(Map.of("unreadCount", count));
     }
 
-    // ========== 알림 상태 변경 ==========
+    /**
+     * 미전송(UNSENT) 데이터 조회 → n8n (웹훅 트리거)
+     */
+    @GetMapping("/unsent")
+    public ResponseEntity<List<NotificationDto.Response>> getUnsentNotifications() {
+        return ResponseEntity.ok(service.getUnsentNotifications());
+    }
 
     /**
-     * 특정 알림 읽음 처리
-     * PATCH /api/notifications/{id}/read
+     * 이메일 대상 조회 (UNSENT + SENT but unread)
+     * GET /api/notifications/email-targets
      */
+    @GetMapping("/email-targets")
+    public ResponseEntity<List<NotificationDto.Response>> getEmailTargets() {
+        return ResponseEntity.ok(service.getEmailTargetNotifications());
+    }
+
+    // =====================================================
+    // 5. 상태 변경
+    // =====================================================
+
     @PatchMapping("/{id}/read")
     public ResponseEntity<Void> markAsRead(
             @AuthenticationPrincipal UserDto.Auth auth,
             @PathVariable Long id) {
-
         service.markAsRead(id, auth.getId());
         return ResponseEntity.ok().build();
     }
 
-    /**
-     * 모든 알림 읽음 처리
-     * PATCH /api/notifications/read-all
-     */
     @PatchMapping("/read-all")
     public ResponseEntity<Void> markAllAsRead(
             @AuthenticationPrincipal UserDto.Auth auth) {
-
         service.markAllAsRead(auth.getId());
         return ResponseEntity.ok().build();
     }
 
-    // ========== 알림 삭제 ==========
+    // =====================================================
+    // 6. 삭제
+    // =====================================================
 
-    /**
-     * 특정 알림 삭제
-     * DELETE /api/notifications/{id}
-     */
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteNotification(
             @AuthenticationPrincipal UserDto.Auth auth,
             @PathVariable Long id) {
-
         service.deleteNotification(id, auth.getId());
         return ResponseEntity.ok().build();
     }
 
-    /**
-     * 미전송 알림 조회 (n8n용)
-     * GET /api/notifications/unsent
-     */
-    @GetMapping("/unsent")
-    public ResponseEntity<List<NotificationDto.Response>> getUnsentNotifications() {
-        List<NotificationDto.Response> unsentNotifications = service.getUnsentNotifications();
-        return ResponseEntity.ok(unsentNotifications);
-    }
+    // =====================================================
+    // 7. SSE 모니터링
+    // =====================================================
 
-    // ========== 모니터링 (관리자용) ==========
-
-    /**
-     * SSE 연결 상태 조회
-     * GET /api/notifications/status
-     * 관리자만 접근 가능하도록 설정 필요
-     */
     @GetMapping("/status")
     public ResponseEntity<Map<String, Object>> getConnectionStatus() {
         return ResponseEntity.ok(service.getConnectionStatus());
     }
 }
+

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/repository/NotificationRepository.java
@@ -40,6 +40,10 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             @Param("since") Long since
     );
 
+    @Query("SELECT n FROM Notification n WHERE (n.status = 'UNSENT' OR n.status = 'SENT') AND n.status <> 'EMAIL_SENT' AND n.status <> 'READ'")
+    List<Notification> findEmailTargets();
+
+
     /**
      * 편의 메서드: 최근 24시간 미전송 알림 조회
      */

--- a/src/main/java/com/halo/core_bridge/api/schedule/notification/service/NotificationService.java
+++ b/src/main/java/com/halo/core_bridge/api/schedule/notification/service/NotificationService.java
@@ -110,6 +110,19 @@ public class NotificationService {
         }
     }
 
+    @Transactional(readOnly = true)
+    public List<NotificationDto.Response> getEmailTargetNotifications() {
+
+        // UNSENT + SENT but not READ + not EMAIL_SENT
+        List<Notification> targets = repository.findEmailTargets();
+
+        log.info("📧 [NotificationService] 이메일 대상 조회: {}건", targets.size());
+
+        return targets.stream()
+                .map(NotificationDto.Response::from)
+                .collect(Collectors.toList());
+    }
+
     // ========== 알림 생성 및 전송 ==========
 
     /**


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

n8n을 이용한 Email 전송 Endpoint 추가,

UNSENT(알람 실패), SENT(읽지 않음) 상태에 대한 인원에 대해 E-mail 발송

## 스크린샷 (선택)

<img width="1528" height="96" alt="image" src="https://github.com/user-attachments/assets/263e0c08-f60b-40fd-a3cc-7ba61100f991" />


# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
