### PR TITLE
feat: 면접 리마인더 기능 추가

### DIFF
--- a/src/main/java/com/halo/core_bridge/api/interview/model/dto/InterviewDto.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/model/dto/InterviewDto.java
@@ -185,4 +185,28 @@ public class InterviewDto {
                     .build();
         }
     }
+
+    @Getter
+    @Builder
+    public static class Reminder {
+
+        private Long id;
+        private String email;
+        private String name;
+        private LocalDate startDate;
+        private LocalTime startTime;
+        private String location;
+
+        public static Reminder from(Interview interview) {
+
+            return Reminder.builder()
+                    .id(interview.getId())
+                    .email(interview.getResume().getUser().getEmail())
+                    .name(interview.getResume().getUser().getName())
+                    .startDate(interview.getStartDateTime().toLocalDate())
+                    .startTime(interview.getStartDateTime().toLocalTime())
+                    .location(interview.getInterviewType().equals(InterviewType.ONLINE) ? "온라인" : interview.getLocation())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/halo/core_bridge/api/interview/model/entity/Interview.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/model/entity/Interview.java
@@ -43,6 +43,12 @@ public class Interview extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private InterviewType interviewType;
 
+    @Column(nullable = false)
+    private boolean reminderSent;
+
+    @Column(nullable = true)
+    private LocalDateTime reminderSentAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     private Resume resume;
 

--- a/src/main/java/com/halo/core_bridge/api/interview/repository/InterviewRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/repository/InterviewRepository.java
@@ -1,9 +1,36 @@
 package com.halo.core_bridge.api.interview.repository;
 
 import com.halo.core_bridge.api.interview.model.entity.Interview;
+import com.halo.core_bridge.api.interview.model.enums.InterviewStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface InterviewRepository extends JpaRepository<Interview, Long> {
 
     boolean existsByRecruitProcess_IdAndResume_Id(Long recruitProcessId, Long resumeId);
+
+    @Query("""
+            select i
+            from Interview i
+            join fetch i.resume r
+            join fetch r.user u
+            where i.startDateTime between :from and :to
+              and i.reminderSent = false
+              and i.status = :status
+            """)
+    List<Interview> findInterviewsToRemind(@Param("from") LocalDateTime from, @Param("to") LocalDateTime to, @Param("status") InterviewStatus status);
+
+    @Modifying
+    @Query("""
+            update Interview i
+               set i.reminderSent = true,
+                   i.reminderSentAt = :now
+             where i.id = :id
+            """)
+    void markReminderSent(@Param("id") Long id, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/halo/core_bridge/api/interview/service/InterviewReminderScheduler.java
+++ b/src/main/java/com/halo/core_bridge/api/interview/service/InterviewReminderScheduler.java
@@ -1,0 +1,48 @@
+package com.halo.core_bridge.api.interview.service;
+
+import com.halo.core_bridge.api.interview.model.entity.Interview;
+import com.halo.core_bridge.api.interview.model.enums.InterviewStatus;
+import com.halo.core_bridge.api.interview.repository.InterviewRepository;
+import com.halo.core_bridge.api.mail.service.InterviewReminderMailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static com.halo.core_bridge.api.interview.model.dto.InterviewDto.Reminder;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InterviewReminderScheduler {
+
+    private static final ZoneId ZONE_KST = ZoneId.of("Asia/Seoul");
+    private static final InterviewStatus STATUS_SCHEDULED = InterviewStatus.SCHEDULED;
+    private final InterviewRepository interviewRepository;
+    private final InterviewReminderMailService interviewReminderMailService;
+
+    @Scheduled(cron = "0 * * * * *")
+    public void sendInterviewReminders() {
+        LocalDateTime now = LocalDateTime.now(ZONE_KST);
+        LocalDateTime from = now.plusHours(1);
+        LocalDateTime to = from.plusMinutes(1);
+
+        List<Interview> interviews = interviewRepository.findInterviewsToRemind(from, to, STATUS_SCHEDULED);
+
+        if (interviews.isEmpty()) {
+            return;
+        }
+
+        log.info("[InterviewReminderScheduler] {} interviews to remind ({} ~ {})",
+                interviews.size(), from, to);
+
+        for (Interview interview : interviews) {
+            Reminder reminder = Reminder.from(interview);
+            interviewReminderMailService.sendToEmail(reminder.getEmail(), reminder);
+        }
+    }
+}

--- a/src/main/java/com/halo/core_bridge/api/jobposting/repository/es/JobPostingSearchOperationRepository.java
+++ b/src/main/java/com/halo/core_bridge/api/jobposting/repository/es/JobPostingSearchOperationRepository.java
@@ -26,7 +26,7 @@ public class JobPostingSearchOperationRepository implements JobPostingSearchRepo
 
         NativeQuery query;
         if (keyword == null || keyword.isBlank()) {
-            // 🔥 키워드 없으면 전체 조회
+            // 키워드 없으면 전체 조회
             query = new NativeQueryBuilder()
                     .withQuery(q ->
                             q.matchAll(

--- a/src/main/java/com/halo/core_bridge/api/mail/model/MailSend.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/model/MailSend.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MailSend {
     AUTH_CODE_MAIL("[CoreBridge] 안녕하세요. 요청하신 인증번호를 보내드립니다.", "AUTH_CODE_MAIL:"),
-    PASSWORD_RESET_MAIL("[CoreBridge] 안녕하세요. 비밀번호 재설정 링크를 보내드립니다.", "PASSWORD_RESET_MAIL:");
+    PASSWORD_RESET_MAIL("[CoreBridge] 안녕하세요. 비밀번호 재설정 링크를 보내드립니다.", "PASSWORD_RESET_MAIL:"),
+    INTERVIEW_REMINDER_MAIL("[CoreBridge] 면접 일정 안내", "INTERVIEW_REMINDER_MAIL:");
 
     private final String subject;
     private final String keyName;

--- a/src/main/java/com/halo/core_bridge/api/mail/service/BaseMailService.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/service/BaseMailService.java
@@ -30,6 +30,30 @@ public abstract class BaseMailService {
         mailSender.send(mimeMessage);
     }
 
+    // 새로운 메서드: 동적 HTML 받기
+    public void sendToEmail(String email, String html) {
+        MimeMessage mimeMessage = createMimeMessage(email, html);
+        mailSender.send(mimeMessage);
+    }
+
+    protected MimeMessage createMimeMessage(String email, String html) {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper messageHelper =
+                    new MimeMessageHelper(mimeMessage, true, DEFAULT_ENCODE);
+
+            messageHelper.setTo(email);
+            messageHelper.setSubject(subject);
+            messageHelper.setText(html, IS_HTML);
+
+        } catch (MessagingException e) {
+            log.error(e.getMessage(), e);
+        }
+
+        return mimeMessage;
+    }
+
     /**
      * MimeMessage 생성
      *

--- a/src/main/java/com/halo/core_bridge/api/mail/service/InterviewReminderMailService.java
+++ b/src/main/java/com/halo/core_bridge/api/mail/service/InterviewReminderMailService.java
@@ -1,0 +1,63 @@
+package com.halo.core_bridge.api.mail.service;
+
+import com.halo.core_bridge.api.interview.repository.InterviewRepository;
+import com.halo.core_bridge.api.mail.model.MailSend;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static com.halo.core_bridge.api.interview.model.dto.InterviewDto.Reminder;
+
+@Slf4j
+@Service
+public class InterviewReminderMailService extends BaseMailService {
+
+    private final InterviewRepository interviewRepository;
+
+    public InterviewReminderMailService(JavaMailSender mailSender, InterviewRepository interviewRepository) {
+        super(mailSender, MailSend.INTERVIEW_REMINDER_MAIL.getSubject());
+        this.interviewRepository = interviewRepository;
+    }
+
+    @Async
+    @Transactional
+    public void sendToEmail(String email, Reminder reminder) {
+
+        String html = """
+                <html>
+                  <body>
+                    <h3>면접 일정 안내</h3>
+                    <p>1시간 후 면접이 시작될 예정입니다.</p>
+                    <ul>
+                       <li><b>시작 시간:</b> %s</li>
+                       <li><b>장소:</b> %s</li>
+                    </ul>
+                  </body>
+                </html>
+                """.formatted(
+                reminder.getStartDate().toString() + " " + reminder.getStartTime().toString(),
+                reminder.getLocation().equals("온라인") ? "온라인" : reminder.getLocation()
+        );
+
+        try {
+            super.sendToEmail(email, html);
+
+            // 메일 전송 성공 → DB 업데이트
+            interviewRepository.markReminderSent(reminder.getId(), LocalDateTime.now());
+
+            log.info("[InterviewReminderMailService] reminder success for interviewId={}", reminder.getId());
+
+        } catch (Exception e) {
+            log.error("Failed to send reminder (async) for interviewId={}", reminder.getId(), e);
+        }
+    }
+
+    @Override
+    protected String createView() {
+        return ""; // 인터뷰 메일은 여기 안 씀
+    }
+}

--- a/src/main/java/com/halo/core_bridge/config/AsyncConfig.java
+++ b/src/main/java/com/halo/core_bridge/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.halo.core_bridge.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/test/java/com/halo/core_bridge/api/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/halo/core_bridge/api/interview/service/InterviewServiceTest.java
@@ -2,7 +2,6 @@ package com.halo.core_bridge.api.interview.service;
 
 import com.halo.core_bridge.api.interview.model.dto.InterviewDto;
 import com.halo.core_bridge.api.interview.model.entity.Interview;
-import com.halo.core_bridge.api.interview.model.entity.Room;
 import com.halo.core_bridge.api.interview.model.enums.InterviewStatus;
 import com.halo.core_bridge.api.interview.repository.InterviewRepository;
 import com.halo.core_bridge.api.jobposting.model.entity.RecruitProcess;
@@ -15,7 +14,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -40,9 +41,6 @@ class InterviewServiceTest {
                 .recruitProcess(
                         RecruitProcess.builder().id(1L).build()
                 )
-                .room(
-                        Room.builder().id(1L).build()
-                )
                 .resume(
                         Resume.builder().id(1L).build()
                 )
@@ -53,12 +51,11 @@ class InterviewServiceTest {
                 .build();
 
         InterviewDto.Create interviewCreateDto = InterviewDto.Create.builder()
-                .startDateTime(LocalDateTime.now())
-                .status(InterviewStatus.ONGOING)
+                .startDate(LocalDate.now())
+                .startTime(LocalTime.now())
                 .description("면접상세")
                 .duration(60)
                 .recruiterProcessId(1L)
-                .roomId(1L)
                 .resumeId(1L)
                 .build();
 


### PR DESCRIPTION
# #️⃣연관된 이슈

> ex) - closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
> 앞에 -를 붙여주면 이슈 이름이 자동으로 연결되요!

- 면접 1시간전 해당되는 지원자에게 이메일을 전송하는 리마인더 기능을 구현하였습니다.

# 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 스크린샷 (선택)

# 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

# 🔗 기타 사항
